### PR TITLE
wayfinder #19: publish drainNativeCrashes() MethodChannel contract

### DIFF
--- a/edge_telemetry_flutter/CHANGELOG.md
+++ b/edge_telemetry_flutter/CHANGELOG.md
@@ -23,6 +23,10 @@ v2.0.0.
 ### 🧹 Internal
 - **REMOVED**: `opentelemetry` dependency, `SpanManager`, `EventTrackerImpl`,
   the `EventTracker` interface, and the `useJsonFormat` dual-backend branches.
+- **ADDED**: `NativeCrashChannel` — the pull-only `edge_telemetry/native_crash`
+  MethodChannel contract (`drainNativeCrashes()` + documented per-crash payload
+  schema) the Phase-4 iOS/Android native plugin builds against. Drained once on
+  init; no-op until the natives land. Internal seam, not exported.
 
 ## [1.6.0] - 2026-07-10
 

--- a/edge_telemetry_flutter/lib/src/crash/native_crash_channel.dart
+++ b/edge_telemetry_flutter/lib/src/crash/native_crash_channel.dart
@@ -1,0 +1,64 @@
+// lib/src/crash/native_crash_channel.dart
+
+import 'package:flutter/services.dart';
+
+/// The one platform-channel seam for native crash capture (#10, spec #15 Phase 4).
+///
+/// Pull-only, single method: Dart calls [drainNativeCrashes] once on init and
+/// the native side returns every *new* `app.crash` payload the OS diagnostic
+/// APIs surfaced since last launch (iOS MetricKit, Android
+/// `ApplicationExitInfo` + `UncaughtExceptionHandler`). There is no push and no
+/// streaming — a crashing process can't call back into Dart, so a next-launch
+/// pull is the only model that works.
+///
+/// This class is the **published contract** the Phase-4 native plugin (Swift +
+/// Kotlin) builds against in parallel. Until that plugin ships, there is no
+/// method-call handler registered for the channel, so [drainNativeCrashes]
+/// catches [MissingPluginException] and returns an empty list — a safe no-op.
+///
+/// ## Per-crash payload schema
+///
+/// Native returns a `List` of maps, one per crash, with these **unprefixed**
+/// keys (the backend's `rum_crash_events` extractors read them verbatim; the
+/// SDK never sends derived fields — server computes `crash_hash`,
+/// `severity_level`, `breadcrumbs`):
+///
+/// | key              | meaning                                    | example                          |
+/// |------------------|--------------------------------------------|----------------------------------|
+/// | `message`        | human-readable summary                     | `"SIGSEGV"` / throwable message  |
+/// | `stacktrace`     | **raw**, unsymbolicated frames (server symbolicates) | callStackTree / tombstone / ANR trace |
+/// | `exception_type` | exception/signal class                     | `"EXC_BAD_ACCESS"` / `"NullPointerException"` |
+/// | `cause`          | `NativeCrash` \| `ANR` \| `Hang`           | `"NativeCrash"`                  |
+/// | `is_fatal`       | always `"true"` for native crashes         | `"true"`                         |
+/// | `crash.source`   | `metrickit` \| `uncaught_handler` \| `app_exit_info` | `"metrickit"`          |
+///
+/// All values arrive as strings. See `docs/wayfinder/native-crash-capture.md` §4.
+class NativeCrashChannel {
+  /// The single channel name shared with the native plugin. Must stay in lock
+  /// step with the Swift/Kotlin side — it is the contract.
+  static const String channelName = 'edge_telemetry/native_crash';
+
+  final MethodChannel _channel;
+
+  NativeCrashChannel({MethodChannel? channel})
+      : _channel = channel ?? const MethodChannel(channelName);
+
+  /// Pull every native crash payload the OS surfaced since the last drain.
+  ///
+  /// Returns an empty list when no native plugin is registered (the current
+  /// state until Phase 4) or when there are no new crashes.
+  Future<List<Map<String, String>>> drainNativeCrashes() async {
+    try {
+      final raw =
+          await _channel.invokeMethod<List<dynamic>>('drainNativeCrashes');
+      if (raw == null) return const [];
+      return raw
+          .whereType<Map>()
+          .map((m) => m.map((k, v) => MapEntry(k.toString(), '$v')))
+          .toList(growable: false);
+    } on MissingPluginException {
+      // No native side wired yet — expected until Phase 4. Safe no-op.
+      return const [];
+    }
+  }
+}

--- a/edge_telemetry_flutter/lib/src/facade/edge_telemetry.dart
+++ b/edge_telemetry_flutter/lib/src/facade/edge_telemetry.dart
@@ -174,6 +174,7 @@ class EdgeTelemetry {
 
       if (config.enableCrashReporting) {
         _installGlobalCrashHandler();
+        await _drainNativeCrashes();
       }
 
       if (config.enableLocalReporting) {
@@ -212,6 +213,20 @@ class EdgeTelemetry {
         print('Stack trace: $stackTrace');
       }
       rethrow;
+    }
+  }
+
+  /// Pull native crashes surfaced by the OS since last launch, once on init.
+  ///
+  /// No-op until the Phase-4 native plugin registers the channel — the drain
+  /// returns `[]` and nothing is sent. When the plugin lands, Phase 4 wires the
+  /// returned payloads into the immediate crash rail here.
+  Future<void> _drainNativeCrashes() async {
+    final crashes = await _wiring!.nativeCrash.drainNativeCrashes();
+    // ponytail: drop until Phase 4; routing to app.crash lands with the native
+    // plugin + the app.crash wire event (spec #15 Phase 4). Contract-only here.
+    if (_config?.debugMode == true && crashes.isNotEmpty) {
+      print('📥 Drained ${crashes.length} native crash(es)');
     }
   }
 

--- a/edge_telemetry_flutter/lib/src/facade/telemetry_wiring.dart
+++ b/edge_telemetry_flutter/lib/src/facade/telemetry_wiring.dart
@@ -11,6 +11,7 @@ import '../core/pipeline.dart';
 import '../core/retry_transport.dart';
 import '../core/config/telemetry_config.dart';
 import '../crash/crash_reporting.dart';
+import '../crash/native_crash_channel.dart';
 import '../managers/breadcrumb_manager.dart';
 import '../managers/context_manager.dart';
 import '../managers/session_manager.dart';
@@ -28,6 +29,7 @@ class TelemetryWiring {
   final ContextManager context;
   final BreadcrumbManager breadcrumbs;
   final CrashReporting crashReporting;
+  final NativeCrashChannel nativeCrash;
   final OfflineQueue queue;
   final RetryTransport transport;
   final Pipeline pipeline;
@@ -48,9 +50,11 @@ class TelemetryWiring {
     required this.pipeline,
     required this.collector,
     required List<DisposeHandle> disposers,
+    NativeCrashChannel? nativeCrash,
     this.navHook,
     this.networkHook,
-  }) : _disposers = disposers;
+  })  : _disposers = disposers,
+        nativeCrash = nativeCrash ?? NativeCrashChannel();
 
   EdgeNavigationObserver? get navigationObserver => navHook?.observer;
 

--- a/edge_telemetry_flutter/test/unit/crash/native_crash_channel_test.dart
+++ b/edge_telemetry_flutter/test/unit/crash/native_crash_channel_test.dart
@@ -1,0 +1,45 @@
+import 'package:edge_telemetry_flutter/src/crash/native_crash_channel.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel(NativeCrashChannel.channelName);
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+  test('no native plugin registered → empty list (safe no-op)', () async {
+    // No handler set: invokeMethod throws MissingPluginException.
+    expect(await NativeCrashChannel().drainNativeCrashes(), isEmpty);
+  });
+
+  test('parses native payloads to List<Map<String,String>>', () async {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      expect(call.method, 'drainNativeCrashes');
+      return <dynamic>[
+        {
+          'message': 'SIGSEGV',
+          'stacktrace': 'frame0\nframe1',
+          'exception_type': 'EXC_BAD_ACCESS',
+          'cause': 'NativeCrash',
+          'is_fatal': true, // non-string coerced to "true"
+          'crash.source': 'metrickit',
+        },
+      ];
+    });
+
+    final crashes = await NativeCrashChannel().drainNativeCrashes();
+    expect(crashes, hasLength(1));
+    expect(crashes.first['cause'], 'NativeCrash');
+    expect(crashes.first['is_fatal'], 'true');
+    expect(crashes.first['crash.source'], 'metrickit');
+  });
+
+  test('null return → empty list', () async {
+    messenger.setMockMethodCallHandler(channel, (call) async => null);
+    expect(await NativeCrashChannel().drainNativeCrashes(), isEmpty);
+  });
+}


### PR DESCRIPTION
Closes #19. Parent: spec #15 (v2.0.0, Phase 2 → unblocks Phase 4). Blocked-by #18 (merged).

## What
Publishes the platform-channel seam the Phase-4 native track builds against in parallel — contract only, no native implementation.

- `NativeCrashChannel` — pull-only `edge_telemetry/native_crash` channel, single method `drainNativeCrashes()` → `List<Map<String,String>>`.
- Per-crash payload schema documented (unprefixed `message` / `stacktrace` / `exception_type` / `cause` / `is_fatal` + `crash.source`), matching `docs/wayfinder/native-crash-capture.md` §4.
- No native side yet: `MissingPluginException → []` (safe no-op until Phase 4).
- Wired into `TelemetryWiring` (fakeable seam), drained **once on init** behind `enableCrashReporting`; payloads dropped until Phase 4 routes them into the crash rail (`ponytail:`-marked).
- CHANGELOG `Internal` note is the publish surface the native tickets reference.

## Acceptance criteria
- [x] MethodChannel `edge_telemetry/native_crash` defined
- [x] `drainNativeCrashes()` signature + payload schema documented
- [x] Dart-side stub in place, called once on init
- [x] Contract published (CHANGELOG + design doc; native tickets reference the Dart source)

## Tests
3 unit tests (no-plugin no-op, payload parse + string coercion, null return). Full suite 21 green, `flutter analyze` clean.

## Notes
- Internal seam — **not** exported from the barrel (consumers must not call `drainNativeCrashes()`).
- Wire held byte-identical to v1.5.2 (native returns nothing yet).