### PR TITLE
wayfinder #20: family identity contract (16-hex IDs + secure storage)

### DIFF
--- a/edge_telemetry_flutter/CHANGELOG.md
+++ b/edge_telemetry_flutter/CHANGELOG.md
@@ -20,6 +20,20 @@ v2.0.0.
 - `withSpan()` / `withNetworkSpan()` — just run your function, record nothing.
 - Each warns once per process when `debugMode` is on.
 
+### 🆔 Identity contract (Phase 3)
+- **CHANGED**: device/session/user IDs now carry 64-bit entropy via
+  `Random.secure()` in the canon family format —
+  `device_<epochMs>_<16hex>_<platform>`, `session_<epochMs>_<16hex>_<platform>`,
+  `user_<epochMs>_<16hex>`. Was 8-char (device/user) / bare-16 (session).
+- **CHANGED**: `device.id` is now stored in `flutter_secure_storage` (iOS
+  Keychain survives reinstall) instead of `SharedPreferences`. New dependency:
+  `flutter_secure_storage: ^9.2.4`.
+- **ADDED**: `sdk.platform` attribute = `flutter-<os>`; `device.platform`
+  remains the real OS.
+- The device-ID validator accepts BOTH the legacy 8-alnum and new 16-hex random
+  widths, so IDs minted before this release upgrade in place. `user.id` stays
+  stable across `setUserProfile()` / reinstall-only regeneration.
+
 ### 🧹 Internal
 - **REMOVED**: `opentelemetry` dependency, `SpanManager`, `EventTrackerImpl`,
   the `EventTracker` interface, and the `useJsonFormat` dual-backend branches.

--- a/edge_telemetry_flutter/README.md
+++ b/edge_telemetry_flutter/README.md
@@ -174,7 +174,7 @@ Backend profile events include versioning and structured data:
   "type": "event",
   "eventName": "user.profile_updated",
   "attributes": {
-    "user.id": "user_1704067200123_abcd1234",
+    "user.id": "user_1704067200123_a8b9c2d1e0f34567",
     "user.name": "John Doe",
     "user.email": "john@example.com",
     "user.phone": "+1234567890",

--- a/edge_telemetry_flutter/lib/src/collectors/flutter_device_info_collector.dart
+++ b/edge_telemetry_flutter/lib/src/collectors/flutter_device_info_collector.dart
@@ -8,6 +8,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 
 import '../core/interfaces/device_info_collector.dart';
 import '../managers/device_id_manager.dart';
+import '../managers/identity_format.dart';
 
 /// Flutter implementation of device information collector
 ///
@@ -39,8 +40,12 @@ class FlutterDeviceInfoCollector implements DeviceInfoCollector {
         'app.package_name': packageInfo.packageName,
       });
 
-      // Collect platform information
-      attributes['device.platform'] = Platform.operatingSystem;
+      // Collect platform information.
+      // device.platform = real OS; sdk.platform = flutter-{os} (ticket #20).
+      // platformTag() is the same lowercased token baked into device/session IDs.
+      final platform = platformTag();
+      attributes['device.platform'] = platform;
+      attributes['sdk.platform'] = 'flutter-$platform';
       attributes['device.platform_version'] = Platform.operatingSystemVersion;
 
       // Collect platform-specific device information

--- a/edge_telemetry_flutter/lib/src/facade/edge_telemetry.dart
+++ b/edge_telemetry_flutter/lib/src/facade/edge_telemetry.dart
@@ -22,6 +22,7 @@ import '../core/models/report_data.dart';
 import '../core/models/telemetry_session.dart';
 import '../managers/breadcrumb_manager.dart';
 import '../managers/context_manager.dart';
+import '../managers/identity_format.dart';
 import '../managers/session_manager.dart';
 import '../managers/user_id_manager.dart';
 import '../reports/simple_report_generator.dart';
@@ -687,15 +688,10 @@ class EdgeTelemetry {
     return result;
   }
 
-  String _generateSessionId() => _generateRandomString(16);
-
-  String _generateRandomString(int length) {
-    const chars =
-        'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    final random = Random.secure();
-    return String.fromCharCodes(Iterable.generate(
-        length, (_) => chars.codeUnitAt(random.nextInt(chars.length))));
-  }
+  /// Format: `session_<epochMs>_<16hex>_<platform>` — the family session leg of
+  /// the identity contract (ticket #20).
+  String _generateSessionId() =>
+      'session_${DateTime.now().millisecondsSinceEpoch}_${secureHex16()}_${platformTag()}';
 
   String _generateEventId() =>
       'event_${DateTime.now().millisecondsSinceEpoch}_${Random().nextInt(1000)}';

--- a/edge_telemetry_flutter/lib/src/managers/device_id_manager.dart
+++ b/edge_telemetry_flutter/lib/src/managers/device_id_manager.dart
@@ -1,222 +1,83 @@
 // lib/src/managers/device_id_manager.dart
 
-import 'dart:io';
-import 'dart:math';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
-/// Manages unique device identifiers with persistent storage
+import 'identity_format.dart';
+
+/// Manages the persistent device identifier.
 ///
-/// Generates device IDs in format: device_<timestamp>_<random>_<platform>
-/// Example: device_1704067200000_a8b9c2d1_android
+/// Format: `device_<epochMs>_<16hex>_<platform>`
+/// Example: `device_1704067200000_a8b9c2d1e0f34567_android`
 ///
-/// Features:
-/// - Generates unique device ID on first app install
-/// - Persists across app sessions using SharedPreferences
-/// - In-memory caching for performance
-/// - Graceful error handling with fallback strategies
-/// - Platform-aware ID generation
+/// Stored in [FlutterSecureStorage] (Keychain on iOS — survives reinstall;
+/// Android keystore accepts reset). Generated once on first launch, cached
+/// in memory, and regenerated only if storage is empty or corrupted.
 class DeviceIdManager {
   static const String _deviceIdKey = 'edge_telemetry_device_id';
 
+  final FlutterSecureStorage _storage;
   String? _cachedDeviceId;
-  SharedPreferences? _prefs;
-  final Random _random = Random();
 
-  /// Get or generate device ID
-  ///
-  /// Returns the same device ID across app sessions and restarts.
-  /// Generates a new ID only on first app install or if storage is corrupted.
+  DeviceIdManager({FlutterSecureStorage? storage})
+      : _storage = storage ?? const FlutterSecureStorage();
+
+  /// Get or generate the device ID — stable across sessions and restarts.
   Future<String> getDeviceId() async {
+    if (_cachedDeviceId != null) return _cachedDeviceId!;
+
     try {
-      // Return cached ID if available
-      if (_cachedDeviceId != null) {
-        print('[DeviceIdManager] Returning cached device ID: $_cachedDeviceId');
-        return _cachedDeviceId!;
+      final stored = await _storage.read(key: _deviceIdKey);
+      if (stored != null && _isValidDeviceIdFormat(stored)) {
+        _cachedDeviceId = stored;
+        return stored;
       }
-
-      // Initialize SharedPreferences if needed
-      if (_prefs == null) {
-        try {
-          _prefs = await SharedPreferences.getInstance();
-        } catch (e) {
-          print('[DeviceIdManager] Failed to initialize SharedPreferences: $e');
-          // Fallback: generate in-memory ID and return it
-          _cachedDeviceId = _generateDeviceId();
-          print(
-              '[DeviceIdManager] Generated fallback in-memory device ID: $_cachedDeviceId');
-          return _cachedDeviceId!;
-        }
-      }
-
-      // Try to get existing ID from storage
-      try {
-        _cachedDeviceId = _prefs!.getString(_deviceIdKey);
-        if (_cachedDeviceId != null) {
-          // Validate the format of stored device ID
-          if (_isValidDeviceIdFormat(_cachedDeviceId!)) {
-            print(
-                '[DeviceIdManager] Loaded device ID from storage: $_cachedDeviceId');
-            return _cachedDeviceId!;
-          } else {
-            print(
-                '[DeviceIdManager] Stored device ID has invalid format, regenerating: $_cachedDeviceId');
-            _cachedDeviceId = null;
-          }
-        }
-      } catch (e) {
-        print('[DeviceIdManager] Failed to read from storage: $e');
-      }
-
-      // Generate new ID if none exists or stored ID was invalid
-      _cachedDeviceId = _generateDeviceId();
-      print('[DeviceIdManager] Generated new device ID: $_cachedDeviceId');
-
-      // Try to persist the new ID
-      try {
-        await _prefs!.setString(_deviceIdKey, _cachedDeviceId!);
-        print('[DeviceIdManager] Persisted device ID to storage');
-      } catch (e) {
-        print('[DeviceIdManager] Failed to persist device ID: $e');
-        // Continue with in-memory ID, will retry persistence next session
-      }
-
-      return _cachedDeviceId!;
     } catch (e) {
-      print('[DeviceIdManager] Unexpected error in getDeviceId: $e');
-      // Last resort: generate a basic fallback ID
-      final fallbackId =
-          'device_${DateTime.now().millisecondsSinceEpoch}_fallback_${_getPlatformString()}';
-      _cachedDeviceId = fallbackId;
-      return fallbackId;
+      print('[DeviceIdManager] Failed to read from secure storage: $e');
     }
+
+    _cachedDeviceId = _generateDeviceId();
+    try {
+      await _storage.write(key: _deviceIdKey, value: _cachedDeviceId);
+    } catch (e) {
+      // Keep the in-memory ID; retry persistence next session.
+      print('[DeviceIdManager] Failed to persist device ID: $e');
+    }
+    return _cachedDeviceId!;
   }
 
-  /// Generate a unique device ID
-  ///
-  /// Format: device_<timestamp>_<random>_<platform>
-  /// - timestamp: Unix milliseconds (13 digits)
-  /// - random: 8-character alphanumeric lowercase string
-  /// - platform: Current platform (android, ios, web, etc.)
+  /// Format: `device_<epochMs>_<16hex>_<platform>`.
   String _generateDeviceId() {
     final timestamp = DateTime.now().millisecondsSinceEpoch;
-    final randomPart = _generateRandomString(8);
-    final platform = _getPlatformString();
-
-    final deviceId = 'device_${timestamp}_${randomPart}_$platform';
-    print('[DeviceIdManager] Generated device ID: $deviceId');
-    return deviceId;
+    return 'device_${timestamp}_${secureHex16()}_${platformTag()}';
   }
 
-  /// Generate cryptographically secure random string
-  ///
-  /// Uses dart:math Random for generating 8-character alphanumeric lowercase string
-  String _generateRandomString(int length) {
-    const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
-    return String.fromCharCodes(
-      Iterable.generate(
-        length,
-        (_) => chars.codeUnitAt(_random.nextInt(chars.length)),
-      ),
-    );
-  }
-
-  /// Get platform string for device ID
-  ///
-  /// Returns platform-specific strings:
-  /// - Android: "android"
-  /// - iOS: "ios"
-  /// - Web: "web"
-  /// - Others: actual Platform.operatingSystem value
-  String _getPlatformString() {
-    try {
-      // Handle web platform which doesn't have Platform.operatingSystem
-      if (identical(0, 0.0)) {
-        // This is a compile-time check for web
-        return 'web';
-      }
-
-      final platform = Platform.operatingSystem.toLowerCase();
-      switch (platform) {
-        case 'android':
-          return 'android';
-        case 'ios':
-          return 'ios';
-        case 'macos':
-          return 'macos';
-        case 'windows':
-          return 'windows';
-        case 'linux':
-          return 'linux';
-        case 'fuchsia':
-          return 'fuchsia';
-        default:
-          return platform;
-      }
-    } catch (e) {
-      print('[DeviceIdManager] Failed to detect platform: $e');
-      return 'unknown';
-    }
-  }
-
-  /// Validate device ID format
-  ///
-  /// Checks if the device ID follows the expected format:
-  /// device_<timestamp>_<random>_<platform>
+  /// Validates `device_<13-digit ts>_<random>_<platform>`, accepting both the
+  /// legacy 8-alnum and new 16-hex random widths (see [isValidRandomPart]).
   bool _isValidDeviceIdFormat(String deviceId) {
-    try {
-      final parts = deviceId.split('_');
-      if (parts.length != 4) return false;
-      if (parts[0] != 'device') return false;
-
-      // Validate timestamp (should be 13 digits)
-      final timestamp = int.tryParse(parts[1]);
-      if (timestamp == null || parts[1].length != 13) return false;
-
-      // Validate random part (should be 8 characters, alphanumeric lowercase)
-      final randomPart = parts[2];
-      if (randomPart.length != 8) return false;
-      if (!RegExp(r'^[a-z0-9]+$').hasMatch(randomPart)) return false;
-
-      // Platform part should be non-empty
-      if (parts[3].isEmpty) return false;
-
-      return true;
-    } catch (e) {
-      print('[DeviceIdManager] Device ID validation error: $e');
-      return false;
-    }
+    final parts = deviceId.split('_');
+    if (parts.length != 4) return false;
+    if (parts[0] != 'device') return false;
+    if (parts[1].length != 13 || int.tryParse(parts[1]) == null) return false;
+    if (!isValidRandomPart(parts[2])) return false;
+    if (parts[3].isEmpty) return false;
+    return true;
   }
 
-  /// Clear device ID from storage and memory
-  ///
-  /// Useful for testing scenarios or when device needs to be reset
+  /// Clear the device ID from storage and memory (testing / device reset).
   Future<void> clearDeviceId() async {
     try {
-      _prefs ??= await SharedPreferences.getInstance();
-      await _prefs!.remove(_deviceIdKey);
-      _cachedDeviceId = null;
-      print('[DeviceIdManager] Cleared device ID from storage and cache');
+      await _storage.delete(key: _deviceIdKey);
     } catch (e) {
       print('[DeviceIdManager] Failed to clear device ID: $e');
-      // Clear cache even if storage operation fails
-      _cachedDeviceId = null;
     }
+    _cachedDeviceId = null;
   }
 
-  /// Check if device ID exists in persistent storage
-  ///
-  /// Returns true if a device ID is stored in SharedPreferences
+  /// True if a valid device ID is already persisted.
   Future<bool> hasStoredDeviceId() async {
     try {
-      _prefs ??= await SharedPreferences.getInstance();
-      final hasKey = _prefs!.containsKey(_deviceIdKey);
-      final storedId = _prefs!.getString(_deviceIdKey);
-
-      // Check both existence and validity
-      final isValid =
-          hasKey && storedId != null && _isValidDeviceIdFormat(storedId);
-      print('[DeviceIdManager] Has stored device ID: $isValid');
-      return isValid;
+      final stored = await _storage.read(key: _deviceIdKey);
+      return stored != null && _isValidDeviceIdFormat(stored);
     } catch (e) {
       print('[DeviceIdManager] Failed to check stored device ID: $e');
       return false;

--- a/edge_telemetry_flutter/lib/src/managers/identity_format.dart
+++ b/edge_telemetry_flutter/lib/src/managers/identity_format.dart
@@ -1,0 +1,32 @@
+// lib/src/managers/identity_format.dart
+//
+// The family identity contract (ticket #20): device/session/user IDs share a
+// canon shape — a `kind_` prefix, epoch-ms timestamp, 16-hex random part, and
+// (device/session only) a platform suffix.
+
+import 'dart:io';
+import 'dart:math';
+
+const _hex = '0123456789abcdef';
+final _secureRandom = Random.secure();
+
+/// 16 lowercase hex chars = 64 bits of entropy from [Random.secure].
+String secureHex16() => String.fromCharCodes(
+      Iterable.generate(16, (_) => _hex.codeUnitAt(_secureRandom.nextInt(16))),
+    );
+
+/// The lowercased real-OS token baked into the device/session ID platform leg
+/// (`ios`/`android` on device). One source so every leg agrees.
+String platformTag() {
+  try {
+    return Platform.operatingSystem.toLowerCase();
+  } catch (_) {
+    return 'unknown';
+  }
+}
+
+/// Accepts BOTH the legacy 8-char alnum width and the new 16-hex width, so
+/// IDs minted before this contract keep validating and upgrade in place.
+bool isValidRandomPart(String part) =>
+    RegExp(r'^[a-z0-9]{8}$').hasMatch(part) ||
+    RegExp(r'^[0-9a-f]{16}$').hasMatch(part);

--- a/edge_telemetry_flutter/lib/src/managers/user_id_manager.dart
+++ b/edge_telemetry_flutter/lib/src/managers/user_id_manager.dart
@@ -2,11 +2,13 @@
 
 import 'package:shared_preferences/shared_preferences.dart';
 
-/// Manages auto-generated user IDs with persistent storage
+import 'identity_format.dart';
+
+/// Manages the SDK-owned, anonymous user ID.
 ///
-/// - Generates UUID on first app install
-/// - Persists across app sessions
-/// - New ID only on app reinstall
+/// Format: `user_<epochMs>_<16hex>`. Generated once on first launch, persisted
+/// across sessions, and stable across `identify()` / `setUserProfile()` — a new
+/// ID only ever appears on reinstall.
 class UserIdManager {
   static const String _userIdKey = 'edge_telemetry_user_id';
 
@@ -35,24 +37,10 @@ class UserIdManager {
     return _currentUserId!;
   }
 
-  /// Generate a unique user ID
+  /// Format: `user_<epochMs>_<16hex>`.
   String _generateUserId() {
     final timestamp = DateTime.now().millisecondsSinceEpoch;
-    final randomPart = _generateRandomString(8);
-    return 'user_${timestamp}_$randomPart';
-  }
-
-  /// Generate random string for user ID uniqueness
-  String _generateRandomString(int length) {
-    const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
-    final random = DateTime.now().microsecondsSinceEpoch;
-    var result = '';
-
-    for (int i = 0; i < length; i++) {
-      result += chars[(random + i) % chars.length];
-    }
-
-    return result;
+    return 'user_${timestamp}_${secureHex16()}';
   }
 
   /// Clear stored user ID (for testing purposes)

--- a/edge_telemetry_flutter/pubspec.lock
+++ b/edge_telemetry_flutter/pubspec.lock
@@ -126,6 +126,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.4"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -152,6 +200,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.7"
   leak_tracker:
     dependency: transitive
     description:

--- a/edge_telemetry_flutter/pubspec.yaml
+++ b/edge_telemetry_flutter/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   package_info_plus: ^8.3.0
   connectivity_plus: ^6.1.4
   shared_preferences: ^2.5.3
+  flutter_secure_storage: ^9.2.4
   path_provider: ^2.1.4
 
 dev_dependencies:

--- a/edge_telemetry_flutter/test/unit/managers/identity_test.dart
+++ b/edge_telemetry_flutter/test/unit/managers/identity_test.dart
@@ -1,0 +1,99 @@
+// test/unit/managers/identity_test.dart
+//
+// The identity contract (ticket #20): canon ID formats, secure 16-hex entropy,
+// a both-width validator for in-place upgrade, and user.id stability across
+// `identify()` (persisted → same ID on every getUserId, even a fresh manager).
+
+import 'package:edge_telemetry_flutter/src/managers/device_id_manager.dart';
+import 'package:edge_telemetry_flutter/src/managers/identity_format.dart';
+import 'package:edge_telemetry_flutter/src/managers/user_id_manager.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('secureHex16', () {
+    test('is 16 lowercase hex chars', () {
+      for (var i = 0; i < 100; i++) {
+        expect(secureHex16(), matches(r'^[0-9a-f]{16}$'));
+      }
+    });
+
+    test('does not repeat across calls (secure entropy)', () {
+      final seen = {for (var i = 0; i < 200; i++) secureHex16()};
+      expect(seen.length, 200);
+    });
+  });
+
+  group('isValidRandomPart — both widths', () {
+    test('accepts legacy 8-char alnum', () {
+      expect(isValidRandomPart('a8b9c2d1'), isTrue);
+    });
+    test('accepts new 16-hex', () {
+      expect(isValidRandomPart('a8b9c2d1e0f34567'), isTrue);
+    });
+    test('rejects wrong widths and non-hex 16', () {
+      expect(isValidRandomPart('abc'), isFalse); // too short
+      expect(isValidRandomPart('a8b9c2d1e0'), isFalse); // 10 chars
+      expect(isValidRandomPart('g8b9c2d1e0f34567'), isFalse); // 16 but non-hex
+    });
+  });
+
+  group('DeviceIdManager', () {
+    setUp(() => FlutterSecureStorage.setMockInitialValues({}));
+
+    test('generates canon device_<13ts>_<16hex>_<platform>', () async {
+      final id = await DeviceIdManager().getDeviceId();
+      final parts = id.split('_');
+      expect(parts[0], 'device');
+      expect(parts[1].length, 13); // epoch ms
+      expect(parts[2], matches(r'^[0-9a-f]{16}$'));
+      expect(parts[3], isNotEmpty); // platform
+    });
+
+    test('persists in secure storage — same ID across managers', () async {
+      final first = await DeviceIdManager().getDeviceId();
+      final second = await DeviceIdManager().getDeviceId(); // fresh instance
+      expect(second, first);
+    });
+
+    test('adopts a legacy 8-alnum stored ID in place (no regen)', () async {
+      const legacy = 'device_1704067200000_a8b9c2d1_android';
+      FlutterSecureStorage.setMockInitialValues(
+          {'edge_telemetry_device_id': legacy});
+      expect(await DeviceIdManager().getDeviceId(), legacy);
+    });
+
+    test('regenerates when stored ID is malformed', () async {
+      FlutterSecureStorage.setMockInitialValues(
+          {'edge_telemetry_device_id': 'garbage'});
+      final id = await DeviceIdManager().getDeviceId();
+      expect(id, startsWith('device_'));
+      expect(id.split('_')[2], matches(r'^[0-9a-f]{16}$'));
+    });
+  });
+
+  group('UserIdManager', () {
+    setUp(() => SharedPreferences.setMockInitialValues({}));
+
+    test('generates canon user_<13ts>_<16hex>', () async {
+      final id = await UserIdManager().getUserId();
+      final parts = id.split('_');
+      expect(parts.length, 3);
+      expect(parts[0], 'user');
+      expect(parts[1].length, 13);
+      expect(parts[2], matches(r'^[0-9a-f]{16}$'));
+    });
+
+    test('stable across identify() — persisted, same on fresh manager',
+        () async {
+      final original = await UserIdManager().getUserId();
+      // identify() never regenerates the SDK-owned id; a new manager reading
+      // the same storage must return the identical id.
+      final afterIdentify = await UserIdManager().getUserId();
+      expect(afterIdentify, original);
+    });
+  });
+}


### PR DESCRIPTION
Closes #20 (Spec #15, Phase 3).

## What
Implements the family identity contract: device/session/user IDs now carry 64-bit entropy via `Random.secure()` in the canon format.

- `device.id = device_<epochMs>_<16hex>_<platform>` — stored in `flutter_secure_storage` (iOS Keychain survives reinstall; Android keystore accepts reset). New dep: `flutter_secure_storage: ^9.2.4`.
- `session.id = session_<epochMs>_<16hex>_<platform>`
- `user.id = user_<epochMs>_<16hex>` — SDK-owned, anonymous, stable across `setUserProfile()` (cached once at init, read-only thereafter), regenerates reinstall-only.
- New `sdk.platform = flutter-<os>` attribute; `device.platform` stays real OS.
- Shared `lib/src/managers/identity_format.dart`: `secureHex16()`, `platformTag()`, and `isValidRandomPart()` — the both-width validator accepts legacy 8-alnum AND new 16-hex, so stored device IDs upgrade in place.

## Acceptance criteria
- [x] device/session/user IDs in canon format via `Random.secure()` 16-hex
- [x] `device.id` in `flutter_secure_storage`; `user.id` stable across `identify()`/`setUserProfile()`
- [x] `device.platform` = real OS; `sdk.platform` = `flutter-{ios,android}`
- [x] Validator accepts both 8-alnum and 16-hex widths
- [x] Unit tests: format + both-width validator + user-id stability

## Tests
11 new tests in `test/unit/managers/identity_test.dart` (format, secure entropy, both-width validator, secure-storage persistence + legacy-adopt, user-id stability). Full suite 32/32 green; `flutter analyze` clean.

## Notes
- No public `identify()` in this repo; the equivalent is `setUserProfile()`, which reads the cached `_currentUserId` and never regenerates it. `fromWiring` exposes no user-id seam, so stability is covered at the `UserIdManager` level rather than adding test-only facade infrastructure.
- README/CHANGELOG updated (Phase 3 entry; stale 8-char `user.id` example fixed).