### PR TITLE
wayfinder #21: flip wire to family canon (telemetry_batch + X-API-Key + 12-event allowlist)

### DIFF
--- a/edge_telemetry_flutter/CHANGELOG.md
+++ b/edge_telemetry_flutter/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## [Unreleased] — 2.0.0-dev
 
-OpenTelemetry removal + sanctioned public-API break (Phase 2 of the atomic
-v2.0.0). Wire behaviour is held byte-identical to 1.5.2 — this slice is a pure
-restructure. Version bump, migration guide, and wire flip land with the rest of
-v2.0.0.
+OpenTelemetry removal + sanctioned public-API break, the identity contract, and
+the **wire flip to the family canon** (Phases 2–3 of the atomic v2.0.0). The
+public Dart API stays backward-compatible; the **wire breaks** — see the wire
+section below. Final version bump + migration guide land with the rest of v2.0.0.
 
 ### 💥 Breaking (source break on upgrade)
 - **REMOVED**: `startSpan()` / `endSpan()` — returned/consumed the deleted OTel
@@ -33,6 +33,34 @@ v2.0.0.
 - The device-ID validator accepts BOTH the legacy 8-alnum and new 16-hex random
   widths, so IDs minted before this release upgrade in place. `user.id` stays
   stable across `setUserProfile()` / reinstall-only regeneration.
+
+### 📡 Wire flip to family canon (Phase 3) — **breaking wire change**
+- **CHANGED**: batch envelope is now `type: "telemetry_batch"` (was `"batch"`),
+  fields ordered `type`/`timestamp`/`batch_size`/`events`.
+- **CHANGED**: transport POSTs to `<endpoint>/collector/telemetry` with an
+  `X-API-Key` header. `endpoint` is now a **base URL** — new `apiKey:` param on
+  `initialize()` supplies the key (omit → header not sent; the Collector 401s).
+- **CHANGED**: the wire now carries **only the 12-event / 4-metric canon
+  allowlist**. Event renames: `navigation.route_change`→`navigation`,
+  `performance.screen_duration` (metric)→`screen.duration` (event),
+  `performance.app_startup`→`page_load`, `network.connectivity_change`→
+  `network_change`; host `trackEvent(name)`→`custom_event` (name in
+  `event.name`); the `user.profile_*` trio folds into one `user.profile.update`.
+- **CHANGED**: metric renames `performance.frame_time`→`frame_render_time`,
+  `performance.memory_usage`→`memory_usage`, `performance.frame_drop` (event)→
+  `long_task` (metric).
+- **REMOVED from wire**: `http.error` / `http.slow_request` (fold into
+  `http.request`), the 4 internal-noise events (`telemetry.initialized`,
+  `*.monitor_initialized`, `performance.system_check`), and the
+  `network.quality_score` / `http.response_time` / `performance.startup_time`
+  metrics.
+- **GUARANTEED**: `location` / `tenant_id` / `geo` are never sent (stripped at
+  the context boundary — the Collector injects them). Batches are capped at
+  1000 events.
+- **CHANGED (config)**: `batchSize` / `flushIntervalMs` / `sampleRate` are the
+  canon keys; `flushIntervalMs` **defaults to 5000ms** (fixes the latent 5-min
+  flush). Old `eventBatchSize` / `batchTimeout` / `maxBatchSize` are deprecated
+  (still honored as fallbacks, removed in v3.0.0).
 
 ### 🧹 Internal
 - **REMOVED**: `opentelemetry` dependency, `SpanManager`, `EventTrackerImpl`,

--- a/edge_telemetry_flutter/README.md
+++ b/edge_telemetry_flutter/README.md
@@ -39,8 +39,9 @@ void main() async {
 
   // 🚀 ONE CALL - EVERYTHING IS AUTOMATIC!
   await EdgeTelemetry.initialize(
-    endpoint: 'https://your-backend.com/api/telemetry',
+    endpoint: 'https://your-backend.com', // base URL — SDK posts to /collector/telemetry
     serviceName: 'my-awesome-app',
+    apiKey: 'edgekey_xxx_yyy', // sent as X-API-Key (required by the collector)
   );
   
   runApp(MyApp());

--- a/edge_telemetry_flutter/lib/src/capture/http_capture_hook.dart
+++ b/edge_telemetry_flutter/lib/src/capture/http_capture_hook.dart
@@ -5,8 +5,8 @@ import 'capture_hook.dart';
 import 'http_overrides.dart';
 
 /// Captures every HTTP request by installing [TelemetryHttpOverrides] globally
-/// and folding each completed request into the same wire events as v1.5.2:
-/// `http.request` (+ `http.response_time` metric, `http.error`, `http.slow_request`).
+/// and folding each completed request into a single canon `http.request` event
+/// (status/duration/success/error all ride in its attributes).
 ///
 /// `dispose` restores the prior `HttpOverrides.global`, so nothing leaks across
 /// hot-restarts.
@@ -33,41 +33,12 @@ class HttpCaptureHook implements CaptureHook {
     };
   }
 
-  /// Byte-identical to v1.5.2 `_trackHttpRequest`. These events flowed through
-  /// the public API in v1.5.2, so they bump session counters.
+  /// Canon: every request completes as a single `http.request` (mapping §2 —
+  /// the old `http.error` / `http.slow_request` / `http.response_time` fold in
+  /// here; `t.toAttributes()` already carries status, duration, success, and any
+  /// error). Bumps session counters, as the HTTP path did in v1.5.2.
   void _emit(EventSink sink, HttpRequestTelemetry t) {
     sink.add(EdgeEvent.event('http.request',
         attributes: t.toAttributes(), countsToSession: true));
-
-    sink.add(EdgeEvent.metric(
-      'http.response_time',
-      t.duration.inMilliseconds.toDouble(),
-      attributes: {
-        'http.method': t.method,
-        'http.status_code': t.statusCode.toString(),
-        'http.category': t.category,
-        'http.performance': t.performanceCategory,
-      },
-      countsToSession: true,
-    ));
-
-    if (!t.isSuccess) {
-      sink.add(EdgeEvent.event('http.error',
-          attributes: {
-            ...t.toAttributes(),
-            'error.type': 'http_error',
-            'error.category': t.category,
-          },
-          countsToSession: true));
-    }
-
-    if (t.duration.inMilliseconds > 2000) {
-      sink.add(EdgeEvent.event('http.slow_request',
-          attributes: {
-            ...t.toAttributes(),
-            'performance.category': 'slow',
-          },
-          countsToSession: true));
-    }
   }
 }

--- a/edge_telemetry_flutter/lib/src/capture/nav_capture_hook.dart
+++ b/edge_telemetry_flutter/lib/src/capture/nav_capture_hook.dart
@@ -9,8 +9,8 @@ import 'capture_hook.dart';
 /// The one consumer-placed hook: the [EdgeNavigationObserver] goes into
 /// `MaterialApp.navigatorObservers`, but its sink (the Collector) is injected
 /// here. Records visited screens + navigation breadcrumbs, then emits the same
-/// `navigation.route_change` / `performance.screen_duration` wire items as
-/// v1.5.2 (which sent them direct — they do not bump session counters).
+/// canon `navigation` + `screen.duration` events direct (which do not bump
+/// session counters).
 class NavCaptureHook implements CaptureHook {
   final SessionManager session;
   final BreadcrumbManager breadcrumbs;
@@ -26,7 +26,7 @@ class NavCaptureHook implements CaptureHook {
   DisposeHandle start(EventSink sink) {
     final observer = EdgeNavigationObserver(
       onEvent: (eventName, {attributes}) {
-        if (eventName == 'navigation.route_change' &&
+        if (eventName == 'navigation' &&
             attributes != null &&
             attributes.containsKey('navigation.to')) {
           session.recordScreen(attributes['navigation.to']!);
@@ -40,10 +40,6 @@ class NavCaptureHook implements CaptureHook {
         }
         sink.add(
             EdgeEvent.event(eventName, attributes: attributes ?? const {}));
-      },
-      onMetric: (name, value, {attributes}) {
-        sink.add(
-            EdgeEvent.metric(name, value, attributes: attributes ?? const {}));
       },
     );
     _observer = observer;

--- a/edge_telemetry_flutter/lib/src/capture/network_capture_hook.dart
+++ b/edge_telemetry_flutter/lib/src/capture/network_capture_hook.dart
@@ -59,7 +59,7 @@ class NetworkCaptureHook implements CaptureHook {
     _currentNetworkType = newType;
     context.networkType = newType;
 
-    sink.add(EdgeEvent.event('network.connectivity_change', attributes: {
+    sink.add(EdgeEvent.event('network_change', attributes: {
       'network.previous_type': previous,
       'network.current_type': newType,
       'network.change_timestamp': DateTime.now().toIso8601String(),

--- a/edge_telemetry_flutter/lib/src/capture/perf_capture_hook.dart
+++ b/edge_telemetry_flutter/lib/src/capture/perf_capture_hook.dart
@@ -59,7 +59,7 @@ class PerfCaptureHook implements CaptureHook {
     final startupMs = DateTime.now().difference(_appStartTime!).inMilliseconds;
     final startupType = _determineStartupType(startupMs);
 
-    sink.add(EdgeEvent.event('performance.app_startup', attributes: {
+    sink.add(EdgeEvent.event('page_load', attributes: {
       'startup.duration_ms': startupMs.toString(),
       'startup.type': startupType,
       'startup.timestamp': DateTime.now().toIso8601String(),
@@ -79,8 +79,7 @@ class PerfCaptureHook implements CaptureHook {
     final frameType = _determineFrameType(totalDuration);
     final isDropped = totalDuration > 16.67;
 
-    sink.add(
-        EdgeEvent.metric('performance.frame_time', totalDuration, attributes: {
+    sink.add(EdgeEvent.metric('frame_render_time', totalDuration, attributes: {
       'frame.build_duration_ms': buildDuration.toString(),
       'frame.raster_duration_ms': rasterDuration.toString(),
       'frame.type': frameType,
@@ -90,7 +89,8 @@ class PerfCaptureHook implements CaptureHook {
 
     if (isDropped) {
       final severity = totalDuration > 33.33 ? 'severe' : 'minor';
-      sink.add(EdgeEvent.event('performance.frame_drop', attributes: {
+      // Canon: a dropped frame is the `long_task` metric (event→metric, §4).
+      sink.add(EdgeEvent.metric('long_task', totalDuration, attributes: {
         'frame.build_duration_ms': buildDuration.toString(),
         'frame.raster_duration_ms': rasterDuration.toString(),
         'frame.total_duration_ms': totalDuration.toString(),
@@ -104,8 +104,7 @@ class PerfCaptureHook implements CaptureHook {
     try {
       final memoryUsage = _getMemoryUsage();
       if (memoryUsage != null) {
-        sink.add(EdgeEvent.metric(
-            'performance.memory_usage', memoryUsage.toDouble(),
+        sink.add(EdgeEvent.metric('memory_usage', memoryUsage.toDouble(),
             attributes: {
               'memory.type': 'rss',
               'memory.unit': 'bytes',

--- a/edge_telemetry_flutter/lib/src/core/collector.dart
+++ b/edge_telemetry_flutter/lib/src/core/collector.dart
@@ -5,6 +5,7 @@ import '../managers/context_manager.dart';
 import '../managers/session_manager.dart';
 import 'edge_event.dart';
 import 'pipeline.dart';
+import 'wire_canon.dart';
 
 /// The single per-event gatekeeper. Every [EdgeEvent] — from a capture hook or a
 /// facade API call — passes through here: sample gate, context merge, session
@@ -36,16 +37,28 @@ class Collector implements EventSink {
   void add(EdgeEvent event) {
     if (!_shouldSample(event)) return;
 
+    // Allowlist gate: only the canon 12 events / 4 metrics reach the wire.
+    // Immediate crashes (app.crash) bypass — they ride their own rail. Drops
+    // happen before counters so noise/folded events don't bump session counts.
+    if (event.priority != EventPriority.immediate &&
+        !isCanonWireItem(event.type, event.name)) {
+      return;
+    }
+
     // Counters bump before enrichment so the event's own session counts
     // include itself (matches v1.5.2 recordEvent-before-enrich ordering).
     if (event.countsToSession) {
       event.type == 'metric' ? session.recordMetric() : session.recordEvent();
     }
 
+    // The single wire choke point for the geo/tenant strip: every path below
+    // (batched, metric, crash) sends this map, and it merges caller-supplied
+    // `event.attributes` — so location/tenant_id/geo are removed here, after the
+    // merge, whether they came from a global or an event attribute (mapping §1).
     final enriched = <String, String>{
       ...context.snapshot(),
       ...event.attributes,
-    };
+    }..removeWhere((k, _) => kForbiddenAttributes.contains(k));
     final timestamp = DateTime.now().toIso8601String();
 
     switch (event.type) {

--- a/edge_telemetry_flutter/lib/src/core/config/telemetry_config.dart
+++ b/edge_telemetry_flutter/lib/src/core/config/telemetry_config.dart
@@ -7,8 +7,16 @@ class TelemetryConfig {
   /// Name of the service/app for telemetry identification
   final String serviceName;
 
-  /// Backend endpoint URL for sending telemetry data
+  /// Base backend URL. The SDK POSTs to `<endpoint>/collector/telemetry`.
   final String endpoint;
+
+  /// API key sent as the `X-API-Key` header. Null = header omitted (the
+  /// Collector 401s without it in api_key mode — dev/self-hosted only).
+  final String? apiKey;
+
+  /// Fraction of sessions kept (0.0–1.0). Config key landed for family
+  /// alignment; the per-session sampling roll is wired in #9.
+  final double sampleRate;
 
   /// Enable debug logging and console output
   final bool debugMode;
@@ -16,10 +24,18 @@ class TelemetryConfig {
   /// Global attributes added to all spans and events
   final Map<String, String> globalAttributes;
 
-  /// Batch timeout for sending telemetry data
+  /// Number of events per batch before a send (canon name).
+  final int batchSize;
+
+  /// Idle time before a partial batch is sent, in ms (canon name; default 5s).
+  final int flushIntervalMs;
+
+  /// Batch timeout for sending telemetry data.
+  @Deprecated('Use flushIntervalMs. Removed in v3.0.0.')
   final Duration batchTimeout;
 
-  /// Maximum number of spans in a batch
+  /// Maximum number of spans in a batch (OTel-era, unused).
+  @Deprecated('Use batchSize. Removed in v3.0.0.')
   final int maxBatchSize;
 
   /// Enable automatic network monitoring (connectivity changes)
@@ -54,14 +70,19 @@ class TelemetryConfig {
   /// Use JSON format instead of OpenTelemetry (simpler for most use cases)
   final bool useJsonFormat;
 
-  /// Number of events to batch before sending
+  /// Number of events to batch before sending.
+  @Deprecated('Use batchSize. Removed in v3.0.0.')
   final int eventBatchSize;
 
   const TelemetryConfig({
     required this.serviceName,
     required this.endpoint,
+    this.apiKey,
+    this.sampleRate = 1.0,
     this.debugMode = false,
     this.globalAttributes = const {},
+    this.batchSize = 30,
+    this.flushIntervalMs = 5000,
     this.batchTimeout = const Duration(seconds: 5),
     this.maxBatchSize = 512,
     this.enableNetworkMonitoring = true,
@@ -81,8 +102,12 @@ class TelemetryConfig {
   TelemetryConfig copyWith({
     String? serviceName,
     String? endpoint,
+    String? apiKey,
+    double? sampleRate,
     bool? debugMode,
     Map<String, String>? globalAttributes,
+    int? batchSize,
+    int? flushIntervalMs,
     Duration? batchTimeout,
     int? maxBatchSize,
     bool? enableNetworkMonitoring,
@@ -100,9 +125,15 @@ class TelemetryConfig {
     return TelemetryConfig(
       serviceName: serviceName ?? this.serviceName,
       endpoint: endpoint ?? this.endpoint,
+      apiKey: apiKey ?? this.apiKey,
+      sampleRate: sampleRate ?? this.sampleRate,
       debugMode: debugMode ?? this.debugMode,
       globalAttributes: globalAttributes ?? this.globalAttributes,
+      batchSize: batchSize ?? this.batchSize,
+      flushIntervalMs: flushIntervalMs ?? this.flushIntervalMs,
+      // ignore: deprecated_member_use_from_same_package
       batchTimeout: batchTimeout ?? this.batchTimeout,
+      // ignore: deprecated_member_use_from_same_package
       maxBatchSize: maxBatchSize ?? this.maxBatchSize,
       enableNetworkMonitoring:
           enableNetworkMonitoring ?? this.enableNetworkMonitoring,
@@ -117,6 +148,7 @@ class TelemetryConfig {
       reportStoragePath: reportStoragePath ?? this.reportStoragePath,
       dataRetentionPeriod: dataRetentionPeriod ?? this.dataRetentionPeriod,
       useJsonFormat: useJsonFormat ?? this.useJsonFormat,
+      // ignore: deprecated_member_use_from_same_package
       eventBatchSize: eventBatchSize ?? this.eventBatchSize,
     );
   }
@@ -151,7 +183,7 @@ EdgeTelemetry Configuration:
   Format: ${useJsonFormat ? 'JSON' : 'OpenTelemetry'}
   Debug: $debugMode
   Features: ${enabledFeatures.entries.where((e) => e.value).map((e) => e.key).join(', ')}
-  Batch: $eventBatchSize events / ${batchTimeout.inSeconds}s
+  Batch: $batchSize events / ${flushIntervalMs}ms
   Local Reports: $enableLocalReporting
 ''';
   }

--- a/edge_telemetry_flutter/lib/src/core/pipeline.dart
+++ b/edge_telemetry_flutter/lib/src/core/pipeline.dart
@@ -21,12 +21,12 @@ class Pipeline {
 
   Pipeline({
     required this.transport,
-    this.batchSize = 30,
-    // ponytail: 5-min flush kept byte-identical with v1.5.2 (the latent 60×
-    // defect). The fix to flushIntervalMs=5s is the Phase-3 wire flip, not #18.
-    this.flushInterval = const Duration(minutes: 5),
+    int batchSize = 30,
+    this.flushInterval = const Duration(seconds: 5),
     this.debugMode = false,
-  });
+    // ponytail: Collector caps batches at 1000 (collector-contract §2); clamp
+    // the flush threshold so the buffer can never exceed it.
+  }) : batchSize = batchSize.clamp(1, 1000);
 
   /// Buffer a batched event; flush when the buffer hits [batchSize].
   void enqueue(Map<String, dynamic> event) {
@@ -55,10 +55,10 @@ class Pipeline {
   void _flush() {
     if (_buffer.isEmpty) return;
     final batch = {
-      'type': 'batch',
-      'events': List<Map<String, dynamic>>.from(_buffer),
-      'batch_size': _buffer.length,
+      'type': 'telemetry_batch',
       'timestamp': DateTime.now().toIso8601String(),
+      'batch_size': _buffer.length,
+      'events': List<Map<String, dynamic>>.from(_buffer),
     };
     transport.send(batch);
     if (debugMode) print('📤 Sent batch of ${_buffer.length} events');

--- a/edge_telemetry_flutter/lib/src/core/retry_transport.dart
+++ b/edge_telemetry_flutter/lib/src/core/retry_transport.dart
@@ -3,6 +3,8 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
+
 import 'offline_queue.dart';
 
 /// Low-level POST primitive. Returns true on a 2xx response. Injectable so tests
@@ -16,20 +18,39 @@ typedef Sender = Future<bool> Function(Map<String, dynamic> payload);
 /// (persist + drain). One persistence/backoff system, not two.
 class RetryTransport {
   final String endpoint;
+  final String? apiKey;
   final OfflineQueue queue;
   final bool debugMode;
 
   final HttpClient _httpClient;
   final Sender? _sender;
 
+  /// The resolved POST target: `<endpoint>/collector/telemetry` (family canon),
+  /// unless [endpoint] already ends with that path.
+  final Uri _url;
+
   RetryTransport({
     required this.endpoint,
     required this.queue,
+    this.apiKey,
     this.debugMode = false,
     HttpClient? httpClient,
     Sender? sender,
   })  : _httpClient = httpClient ?? HttpClient(),
-        _sender = sender;
+        _sender = sender,
+        _url = _resolveUrl(endpoint);
+
+  /// The resolved POST target (test seam).
+  @visibleForTesting
+  Uri get resolvedUrl => _url;
+
+  static Uri _resolveUrl(String endpoint) {
+    final base = endpoint.endsWith('/')
+        ? endpoint.substring(0, endpoint.length - 1)
+        : endpoint;
+    if (base.endsWith('/collector/telemetry')) return Uri.parse(base);
+    return Uri.parse('$base/collector/telemetry');
+  }
 
   /// Send a batch. Byte-identical to v1.5.2 `JsonHttpClient.sendTelemetryData`.
   /// On success, opportunistically drains any queued crash payloads.
@@ -82,8 +103,9 @@ class RetryTransport {
 
   Future<bool> _httpPost(Map<String, dynamic> data) async {
     try {
-      final request = await _httpClient.postUrl(Uri.parse(endpoint));
+      final request = await _httpClient.postUrl(_url);
       request.headers.set('Content-Type', 'application/json');
+      if (apiKey != null) request.headers.set('X-API-Key', apiKey!);
       request.write(json.encode(data));
       final response = await request.close();
 

--- a/edge_telemetry_flutter/lib/src/core/wire_canon.dart
+++ b/edge_telemetry_flutter/lib/src/core/wire_canon.dart
@@ -1,0 +1,40 @@
+// lib/src/core/wire_canon.dart
+//
+// The family wire allowlist (eventname-envelope-mapping.md §2/§4). The Collector
+// drops any batched event/metric whose name is not on these lists, so only canon
+// signal reaches the wire. Capture hooks emit canon names at the source; this is
+// the enforced boundary + the anchor the wire snapshot test asserts against.
+
+/// The 12 canon event names (§2). `app.crash` rides the immediate crash rail,
+/// not the batch, but is listed here for completeness.
+const Set<String> kCanonEvents = {
+  'session.started',
+  'session.finalized',
+  'app_lifecycle',
+  'page_load',
+  'navigation',
+  'screen.duration',
+  'http.request',
+  'user.interaction',
+  'network_change',
+  'user.profile.update',
+  'custom_event',
+  'app.crash',
+};
+
+/// The 4 canon metric names (§4).
+const Set<String> kCanonMetrics = {
+  'frame_render_time',
+  'memory_usage',
+  'long_task',
+  'resource_timing',
+};
+
+/// Attribute keys the SDK must never send — the Collector is the single source
+/// of geo/tenant truth (mapping §1, injected from client IP + API key).
+const Set<String> kForbiddenAttributes = {'location', 'tenant_id', 'geo'};
+
+/// Whether a batched item of [type] (`event`/`metric`) named [name] is canon.
+bool isCanonWireItem(String type, String name) => type == 'metric'
+    ? kCanonMetrics.contains(name)
+    : kCanonEvents.contains(name);

--- a/edge_telemetry_flutter/lib/src/facade/edge_telemetry.dart
+++ b/edge_telemetry_flutter/lib/src/facade/edge_telemetry.dart
@@ -85,10 +85,15 @@ class EdgeTelemetry {
   static Future<void> initialize({
     required String endpoint,
     required String serviceName,
+    String? apiKey,
+    double sampleRate = 1.0,
     bool debugMode = false,
     Map<String, String>? globalAttributes,
+    int? batchSize,
+    int? flushIntervalMs,
+    @Deprecated('Use flushIntervalMs. Removed in v3.0.0.')
     Duration? batchTimeout,
-    int? maxBatchSize,
+    @Deprecated('Ignored (OTel-era). Removed in v3.0.0.') int? maxBatchSize,
     bool enableNetworkMonitoring = true,
     bool enablePerformanceMonitoring = true,
     bool enableNavigationTracking = true,
@@ -100,15 +105,22 @@ class EdgeTelemetry {
     @Deprecated(
         'useJsonFormat is ignored; the SDK is custom-JSON only. Remove the argument. Removed in v3.0.0.')
     bool useJsonFormat = true,
-    int eventBatchSize = 30,
+    @Deprecated('Use batchSize. Removed in v3.0.0.') int? eventBatchSize,
   }) async {
+    // New canon keys win; deprecated keys are the fallback (backward-compat).
+    final resolvedBatchSize = batchSize ?? eventBatchSize ?? 30;
+    final resolvedFlushMs =
+        flushIntervalMs ?? batchTimeout?.inMilliseconds ?? 5000;
+
     final config = TelemetryConfig(
       endpoint: endpoint,
       serviceName: serviceName,
+      apiKey: apiKey,
+      sampleRate: sampleRate,
       debugMode: debugMode,
       globalAttributes: globalAttributes ?? {},
-      batchTimeout: batchTimeout ?? const Duration(seconds: 5),
-      maxBatchSize: maxBatchSize ?? 512,
+      batchSize: resolvedBatchSize,
+      flushIntervalMs: resolvedFlushMs,
       enableNetworkMonitoring: enableNetworkMonitoring,
       enablePerformanceMonitoring: enablePerformanceMonitoring,
       enableNavigationTracking: enableNavigationTracking,
@@ -117,7 +129,8 @@ class EdgeTelemetry {
       reportStoragePath: reportStoragePath,
       dataRetentionPeriod: dataRetentionPeriod ?? const Duration(days: 30),
       useJsonFormat: true, // custom-JSON is the only backend now
-      eventBatchSize: eventBatchSize,
+      // ignore: deprecated_member_use_from_same_package
+      eventBatchSize: resolvedBatchSize,
       enableHttpMonitoring: enableHttpMonitoring,
       enableCrashReporting: enableCrashReporting,
     );
@@ -249,8 +262,11 @@ class EdgeTelemetry {
     _ensureInitialized();
     final stringAttributes = _convertToStringMap(attributes);
 
-    _wiring!.collector.add(EdgeEvent.event(eventName,
-        attributes: stringAttributes, countsToSession: true));
+    // Host names are arbitrary → wrap into the canon `custom_event` with the
+    // host-supplied name carried in `event.name` (mapping §2).
+    _wiring!.collector.add(EdgeEvent.event('custom_event',
+        attributes: {'event.name': eventName, ...stringAttributes},
+        countsToSession: true));
 
     if (isLocalReportingEnabled && _currentSessionId != null) {
       final event = TelemetryEvent(
@@ -367,16 +383,8 @@ class EdgeTelemetry {
       }
     }
 
-    _emitProfileEvent('user.profile_updated', profileEventAttributes);
-    _emitProfileEvent('user.profile_set', {
-      'user.has_name': (name != null).toString(),
-      'user.has_email': (email != null).toString(),
-      'user.has_phone': (phone != null).toString(),
-      'user.custom_attributes_count':
-          (customAttributes?.length ?? 0).toString(),
-      'profile_timestamp': DateTime.now().toIso8601String(),
-      'profile_version': profileVersion.toString(),
-    });
+    // Canon: one `user.profile.update` (folds v1 profile_updated/set/cleared).
+    _emitProfileEvent('user.profile.update', profileEventAttributes);
   }
 
   /// Emit a profile event direct — no session-counter bump, no local store —
@@ -392,13 +400,10 @@ class EdgeTelemetry {
     _userProfile.clear();
     final profileVersion = _getNextProfileVersion();
 
-    _emitProfileEvent('user.profile_updated', {
+    _emitProfileEvent('user.profile.update', {
       'user.id': _currentUserId!,
       'user.profile_version': profileVersion.toString(),
       'user.profile_updated_at': DateTime.now().toIso8601String(),
-    });
-    _emitProfileEvent('user.profile_cleared', {
-      'profile_version': profileVersion.toString(),
     });
   }
 

--- a/edge_telemetry_flutter/lib/src/facade/telemetry_wiring.dart
+++ b/edge_telemetry_flutter/lib/src/facade/telemetry_wiring.dart
@@ -70,6 +70,7 @@ class TelemetryWiring {
 
     final transport = RetryTransport(
       endpoint: config.endpoint,
+      apiKey: config.apiKey,
       queue: queue,
       debugMode: config.debugMode,
     );
@@ -78,7 +79,8 @@ class TelemetryWiring {
 
     final pipeline = Pipeline(
       transport: transport,
-      batchSize: config.eventBatchSize,
+      batchSize: config.batchSize,
+      flushInterval: Duration(milliseconds: config.flushIntervalMs),
       debugMode: config.debugMode,
     );
 

--- a/edge_telemetry_flutter/lib/src/managers/context_manager.dart
+++ b/edge_telemetry_flutter/lib/src/managers/context_manager.dart
@@ -26,6 +26,9 @@ class ContextManager {
 
   /// The enriched attribute set right now: globals, then live session attrs,
   /// then `network.type`. Order matches v1.5.2 `_getEnrichedAttributes`.
+  ///
+  /// The geo/tenant strip (`location`/`tenant_id`/`geo`) lives in `Collector`,
+  /// downstream of where event attributes merge in — see `Collector.add`.
   Map<String, String> snapshot() => {
         ..._global,
         ...sessionManager.getSessionAttributes(),

--- a/edge_telemetry_flutter/lib/src/widgets/edge_navigation_observer.dart
+++ b/edge_telemetry_flutter/lib/src/widgets/edge_navigation_observer.dart
@@ -11,13 +11,10 @@ class EdgeNavigationObserver extends NavigatorObserver {
   final Map<String, DateTime> _screenStartTimes = {};
 
   final Function(String, {Map<String, String>? attributes})? _onEvent;
-  final Function(String, double, {Map<String, String>? attributes})? _onMetric;
 
   EdgeNavigationObserver({
     Function(String, {Map<String, String>? attributes})? onEvent,
-    Function(String, double, {Map<String, String>? attributes})? onMetric,
-  })  : _onEvent = onEvent,
-        _onMetric = onMetric;
+  }) : _onEvent = onEvent;
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
@@ -93,13 +90,12 @@ class EdgeNavigationObserver extends NavigatorObserver {
     if (startTime == null) return;
 
     final duration = DateTime.now().difference(startTime);
-    _onMetric?.call(
-        'performance.screen_duration', duration.inMilliseconds.toDouble(),
-        attributes: {
-          'screen.name': routeName,
-          'navigation.exit_method': exitMethod,
-          'metric.unit': 'milliseconds',
-        });
+    // Canon: screen dwell is the `screen.duration` event (metric→event, §2).
+    _onEvent?.call('screen.duration', attributes: {
+      'screen.name': routeName,
+      'screen.duration_ms': duration.inMilliseconds.toString(),
+      'screen.exit_method': exitMethod,
+    });
   }
 
   /// Track navigation event
@@ -124,7 +120,7 @@ class EdgeNavigationObserver extends NavigatorObserver {
           route.settings.arguments.runtimeType.toString();
     }
 
-    _onEvent?.call('navigation.route_change', attributes: navigationAttributes);
+    _onEvent?.call('navigation', attributes: navigationAttributes);
   }
 
   /// Clean up any remaining timing for a route

--- a/edge_telemetry_flutter/test/fixtures/canon_telemetry_batch.json
+++ b/edge_telemetry_flutter/test/fixtures/canon_telemetry_batch.json
@@ -1,0 +1,28 @@
+{
+  "_comment": "Golden canon batch shape (eventname-envelope-mapping.md §1/§2/§4). Volatile timestamps are '<TS>'; session.*/network.* attrs are normalized out before comparison (they are #9's concern, not the wire-flip canon).",
+  "type": "telemetry_batch",
+  "timestamp": "<TS>",
+  "batch_size": 2,
+  "events": [
+    {
+      "type": "event",
+      "eventName": "navigation",
+      "timestamp": "<TS>",
+      "attributes": {
+        "device.id": "device_abc",
+        "user.id": "user_abc",
+        "navigation.to": "/home"
+      }
+    },
+    {
+      "type": "metric",
+      "metricName": "frame_render_time",
+      "value": 12.5,
+      "timestamp": "<TS>",
+      "attributes": {
+        "device.id": "device_abc",
+        "user.id": "user_abc"
+      }
+    }
+  ]
+}

--- a/edge_telemetry_flutter/test/unit/architecture/seams_test.dart
+++ b/edge_telemetry_flutter/test/unit/architecture/seams_test.dart
@@ -116,17 +116,19 @@ void main() {
 
       expect(sender.sent, hasLength(1));
       final batch = sender.sent.single;
-      expect(batch['type'], 'batch');
+      expect(batch['type'], 'telemetry_batch');
       final events = batch['events'] as List;
-      expect(events.single['eventName'], 'demo.click');
+      // Host names wrap into custom_event with event.name carrying the name.
+      expect(events.single['eventName'], 'custom_event');
       final attrs = events.single['attributes'] as Map;
+      expect(attrs['event.name'], 'demo.click');
       expect(attrs['button'], 'x');
       expect(attrs['device.id'], 'device_x');
     });
   });
 
   group('Seam 2 — EventSink injected into a CaptureHook', () {
-    test('NavCaptureHook emits navigation.route_change to a fake sink', () {
+    test('NavCaptureHook emits navigation to a fake sink', () {
       final sink = _FakeSink();
       final hook = NavCaptureHook(
           session: SessionManager(), breadcrumbs: BreadcrumbManager());
@@ -139,8 +141,7 @@ void main() {
         null,
       );
 
-      final nav =
-          sink.events.firstWhere((e) => e.name == 'navigation.route_change');
+      final nav = sink.events.firstWhere((e) => e.name == 'navigation');
       expect(nav.type, 'event');
       expect(nav.attributes['navigation.to'], '/home');
       expect(nav.countsToSession, isFalse); // nav sent direct in v1.5.2
@@ -182,7 +183,7 @@ void main() {
 
       expect(sender.sent, hasLength(1));
       final batch = sender.sent.single;
-      expect(batch['type'], 'batch');
+      expect(batch['type'], 'telemetry_batch');
       expect(batch['batch_size'], 2);
       expect((batch['events'] as List).map((e) => e['eventName']), ['a', 'b']);
     });
@@ -215,7 +216,8 @@ void main() {
       final collector =
           Collector(context: context, session: session, pipeline: pipeline);
 
-      collector.add(const EdgeEvent.event('batched.dropped'));
+      // A canon event (passes the allowlist) so the drop is purely sampling.
+      collector.add(const EdgeEvent.event('navigation'));
       await Future<void>(() {});
       expect(sender.sent, isEmpty); // batched event dropped
 

--- a/edge_telemetry_flutter/test/unit/core/wire_flip_test.dart
+++ b/edge_telemetry_flutter/test/unit/core/wire_flip_test.dart
@@ -1,0 +1,185 @@
+// test/unit/core/wire_flip_test.dart
+//
+// The Phase-3 wire flip (#21): the assembled batch must match the family canon.
+// Drives real EdgeEvents through Collector → Pipeline → transport and snapshots
+// the envelope, allowlist filtering, http folding, metric renames, device.id
+// presence, and the geo/tenant strip.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:edge_telemetry_flutter/src/core/collector.dart';
+import 'package:edge_telemetry_flutter/src/core/edge_event.dart';
+import 'package:edge_telemetry_flutter/src/core/offline_queue.dart';
+import 'package:edge_telemetry_flutter/src/core/pipeline.dart';
+import 'package:edge_telemetry_flutter/src/core/retry_transport.dart';
+import 'package:edge_telemetry_flutter/src/managers/context_manager.dart';
+import 'package:edge_telemetry_flutter/src/managers/session_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _RecordingSender {
+  final List<Map<String, dynamic>> sent = [];
+  Future<bool> call(Map<String, dynamic> payload) async {
+    sent.add(payload);
+    return true;
+  }
+}
+
+class _NoopQueue extends OfflineQueue {
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<String?> persist(Map<String, dynamic> p) async => null;
+  @override
+  Future<int> drain(Future<bool> Function(Map<String, dynamic>) s) async => 0;
+}
+
+/// Build a Collector wired to a recording sender; [flushAt] events per batch.
+Future<(Collector, _RecordingSender)> _wire({
+  int flushAt = 100,
+  Map<String, String>? global,
+  String endpoint = 'https://api.example.test',
+  String? apiKey,
+}) async {
+  final sender = _RecordingSender();
+  final session = SessionManager();
+  await session.startSession('session_test');
+  final context = ContextManager(
+    sessionManager: session,
+    global: global ?? {'device.id': 'device_abc', 'user.id': 'user_abc'},
+  );
+  final transport = RetryTransport(
+      endpoint: endpoint,
+      apiKey: apiKey,
+      queue: _NoopQueue(),
+      sender: sender.call);
+  final pipeline = Pipeline(transport: transport, batchSize: flushAt);
+  final collector =
+      Collector(context: context, session: session, pipeline: pipeline);
+  return (collector, sender);
+}
+
+/// Normalize an assembled batch for golden comparison: blank the volatile
+/// timestamps and drop the session.*/network.* attrs (owned by #9, not the
+/// wire-flip canon this fixture pins).
+Map<String, dynamic> _normalize(Map<String, dynamic> batch) => {
+      ...batch,
+      'timestamp': '<TS>',
+      'events': (batch['events'] as List).map((e) {
+        final ev = Map<String, dynamic>.from(e as Map);
+        ev['timestamp'] = '<TS>';
+        ev['attributes'] = Map<String, dynamic>.from(ev['attributes'] as Map)
+          ..removeWhere(
+              (k, _) => k.startsWith('session.') || k.startsWith('network.'));
+        return ev;
+      }).toList(),
+    };
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  test('batch envelope matches canon: telemetry_batch + fields + device.id',
+      () async {
+    final (collector, sender) = await _wire(flushAt: 2);
+
+    collector.add(const EdgeEvent.event('navigation',
+        attributes: {'navigation.to': '/home'}));
+    collector.add(const EdgeEvent.metric('frame_render_time', 12.5));
+    await Future<void>(() {});
+
+    expect(sender.sent, hasLength(1));
+    final batch = sender.sent.single;
+    expect(batch.keys.toList(), ['type', 'timestamp', 'batch_size', 'events']);
+    expect(batch['type'], 'telemetry_batch');
+    expect(batch['batch_size'], 2);
+
+    final events = (batch['events'] as List).cast<Map<String, dynamic>>();
+    expect(events.map((e) => e['eventName'] ?? e['metricName']),
+        ['navigation', 'frame_render_time']);
+    // device.id rides in every event's attributes (Collector 400s without it).
+    for (final e in events) {
+      expect((e['attributes'] as Map)['device.id'], 'device_abc');
+    }
+    // The metric keeps metricName + value at root (shape unchanged).
+    expect(events[1]['metricName'], 'frame_render_time');
+    expect(events[1]['value'], 12.5);
+  });
+
+  test('allowlist gate: canon kept, noise + folded http + dropped metrics out',
+      () async {
+    final (collector, sender) = await _wire(flushAt: 1);
+
+    // Non-canon → all dropped, nothing flushes.
+    collector.add(const EdgeEvent.event('telemetry.initialized'));
+    collector.add(const EdgeEvent.event('http.error'));
+    collector.add(const EdgeEvent.event('http.slow_request'));
+    collector.add(const EdgeEvent.event('performance.memory_pressure'));
+    collector.add(const EdgeEvent.metric('http.response_time', 1));
+    collector.add(const EdgeEvent.metric('network.quality_score', 4));
+    collector.add(const EdgeEvent.metric('performance.startup_time', 1));
+    await Future<void>(() {});
+    expect(sender.sent, isEmpty);
+
+    // Canon http.request survives (the fold target).
+    collector.add(const EdgeEvent.event('http.request',
+        attributes: {'http.success': 'true'}));
+    await Future<void>(() {});
+    expect(sender.sent, hasLength(1));
+    expect((sender.sent.single['events'] as List).single['eventName'],
+        'http.request');
+  });
+
+  test('geo/tenant never reach the wire — from globals OR event attributes',
+      () async {
+    final (collector, sender) = await _wire(flushAt: 1, global: {
+      'device.id': 'device_abc',
+      'location': 'Nairobi', // global path
+      'tenant_id': 't_1',
+    });
+
+    // geo arrives via event attributes — must still be stripped (the merge in
+    // Collector.add spreads event.attributes over the snapshot).
+    collector
+        .add(const EdgeEvent.event('navigation', attributes: {'geo': 'KE'}));
+    await Future<void>(() {});
+
+    final attrs =
+        (sender.sent.single['events'] as List).single['attributes'] as Map;
+    expect(attrs['device.id'], 'device_abc');
+    expect(attrs.containsKey('location'), isFalse);
+    expect(attrs.containsKey('tenant_id'), isFalse);
+    expect(attrs.containsKey('geo'), isFalse);
+  });
+
+  test('assembled batch matches the family-canon golden fixture', () async {
+    final (collector, sender) = await _wire(flushAt: 2);
+    collector.add(const EdgeEvent.event('navigation',
+        attributes: {'navigation.to': '/home'}));
+    collector.add(const EdgeEvent.metric('frame_render_time', 12.5));
+    await Future<void>(() {});
+
+    final golden = (jsonDecode(
+            File('test/fixtures/canon_telemetry_batch.json').readAsStringSync())
+        as Map<String, dynamic>)
+      ..remove('_comment');
+
+    expect(_normalize(sender.sent.single), golden);
+  });
+
+  test('transport resolves <endpoint>/collector/telemetry (base or suffixed)',
+      () {
+    Uri url(String endpoint) =>
+        RetryTransport(endpoint: endpoint, queue: _NoopQueue()).resolvedUrl;
+
+    expect(url('https://api.example.test').toString(),
+        'https://api.example.test/collector/telemetry');
+    // Trailing slash is not doubled.
+    expect(url('https://api.example.test/').toString(),
+        'https://api.example.test/collector/telemetry');
+    // Already-canon path is left intact (not double-appended).
+    expect(url('https://api.example.test/collector/telemetry').toString(),
+        'https://api.example.test/collector/telemetry');
+  });
+}


### PR DESCRIPTION
Phase 3 of the atomic v2.0.0 — flips the wire from v1 to the Edge RUM family canon. Public Dart API stays backward-compatible; the wire breaks (allowed at v2.0.0).

> **Stacked on #35 (wayfinder #20).** Based on `wayfinder-20-identity-contract` so this PR shows only the #21 diff. Retarget to `master` once #35 merges.

## Envelope + transport
- Batch envelope `type:"telemetry_batch"` (was `"batch"`), ordered type/timestamp/batch_size/events.
- POST `<endpoint>/collector/telemetry` with an `X-API-Key` header. `endpoint` is now a base URL; new optional `apiKey:` on `initialize()`.

## Allowlist + renames (only canon 12 events / 4 metrics on the wire)
- New `wire_canon.dart` allowlist; the Collector drops any batched event/metric outside it (before session counters).
- Renames at source: `navigation.route_change`→`navigation`, `screen_duration` metric→`screen.duration` event, `app_startup`→`page_load`, `connectivity_change`→`network_change`; `frame_time`→`frame_render_time`, `memory_usage`→`memory_usage`, `frame_drop` event→`long_task` metric.
- `http.error`/`http.slow_request`/`http.response_time` fold into a single `http.request`.
- `trackEvent`→`custom_event` (name in `event.name`); the `user.profile_*` trio folds into one `user.profile.update`.
- The 4 internal-noise events + `network.quality_score` are dropped by the gate.

## Guarantees
- `location`/`tenant_id`/`geo` stripped in `Collector.add` (after event attrs merge) — never sent from any source.
- Batches capped at 1000; `device.id` rides every event.

## Config (terminology firewall)
- Canon keys `batchSize`/`flushIntervalMs`/`sampleRate`; `flushIntervalMs` defaults to 5000ms (fixes the latent 5-min flush). Old `eventBatchSize`/`batchTimeout`/`maxBatchSize` deprecated, still honored as fallbacks.

## Tests
`flutter analyze` clean; 37/37 pass. New `wire_flip_test` (envelope, allowlist, http fold, geo/tenant strip from globals AND event attrs, URL resolution, golden canon fixture); `seams_test` updated. README/CHANGELOG updated.

Closes #21