### PR TITLE
wayfinder #22: crash unification — all Dart handlers → one app.crash

### DIFF
--- a/edge_telemetry_flutter/CHANGELOG.md
+++ b/edge_telemetry_flutter/CHANGELOG.md
@@ -57,6 +57,15 @@ section below. Final version bump + migration guide land with the rest of v2.0.0
 - **GUARANTEED**: `location` / `tenant_id` / `geo` are never sent (stripped at
   the context boundary — the Collector injects them). Batches are capped at
   1000 events.
+- **CHANGED (crash unification)**: the bare `type:"error"` item is gone — every
+  Dart error path (`FlutterError.onError`, `PlatformDispatcher.onError`,
+  `runZonedGuarded`, the now-wired isolate error-listener, host `trackError`)
+  funnels into one immediate `app.crash` **event** with **unprefixed** keys
+  (`message`, `stacktrace`, `exception_type`, `cause="Error"`, `is_fatal=false`)
+  and the catching handler in the secondary `crash.source`
+  (`flutter_error`/`platform_dispatcher`/`zone`/`isolate`). The client no longer
+  derives `crash_hash` / `severity` / `breadcrumbs` — the server computes those.
+  Crashes still send immediately and persist+drain on network failure.
 - **CHANGED (config)**: `batchSize` / `flushIntervalMs` / `sampleRate` are the
   canon keys; `flushIntervalMs` **defaults to 5000ms** (fixes the latent 5-min
   flush). Old `eventBatchSize` / `batchTimeout` / `maxBatchSize` are deprecated

--- a/edge_telemetry_flutter/lib/src/core/collector.dart
+++ b/edge_telemetry_flutter/lib/src/core/collector.dart
@@ -61,35 +61,29 @@ class Collector implements EventSink {
     }..removeWhere((k, _) => kForbiddenAttributes.contains(k));
     final timestamp = DateTime.now().toIso8601String();
 
-    switch (event.type) {
-      case 'metric':
-        pipeline.enqueue({
-          'type': 'metric',
-          'metricName': event.name,
-          'value': event.value,
-          'timestamp': timestamp,
-          'attributes': enriched,
-        });
-        break;
-      case 'error':
-        pipeline.sendNow({
-          'type': 'error',
-          'error': event.error.toString(),
-          'timestamp': timestamp,
-          'attributes': enriched,
-          if (event.stackTrace != null)
-            'stackTrace': event.stackTrace.toString(),
-          if (enriched['crash.fingerprint'] != null)
-            'fingerprint': enriched['crash.fingerprint'],
-        });
-        break;
-      default: // 'event'
-        pipeline.enqueue({
-          'type': 'event',
-          'eventName': event.name,
-          'timestamp': timestamp,
-          'attributes': enriched,
-        });
+    final wireItem = event.type == 'metric'
+        ? {
+            'type': 'metric',
+            'metricName': event.name,
+            'value': event.value,
+            'timestamp': timestamp,
+            'attributes': enriched,
+          }
+        : {
+            // 'event' — incl. the immediate `app.crash` (unprefixed keys ride in
+            // `enriched`; there is no bare `type:"error"` item on the wire in v2).
+            'type': 'event',
+            'eventName': event.name,
+            'timestamp': timestamp,
+            'attributes': enriched,
+          };
+
+    // Two send rails: crashes (and any immediate event) bypass the batch; every
+    // batched event/metric buffers in the Pipeline.
+    if (event.priority == EventPriority.immediate) {
+      pipeline.sendNow(wireItem);
+    } else {
+      pipeline.enqueue(wireItem);
     }
   }
 }

--- a/edge_telemetry_flutter/lib/src/core/edge_event.dart
+++ b/edge_telemetry_flutter/lib/src/core/edge_event.dart
@@ -60,13 +60,39 @@ class EdgeEvent {
         stackTrace = null,
         priority = EventPriority.batched;
 
-  const EdgeEvent.error(
-    this.error, {
-    this.stackTrace,
-    this.attributes = const {},
-  })  : type = 'error',
-        name = '',
+  /// The single source of truth for the `app.crash` wire shape.
+  ///
+  /// Every Dart error path (facade `trackError`, the auto-installed
+  /// `FlutterError.onError` / `PlatformDispatcher.onError` / isolate handlers,
+  /// and the SDK's own capture-hook self-diagnostics) funnels through here, so
+  /// they all produce one immediate `app.crash` event with **unprefixed** keys
+  /// (`message`, `stacktrace`, `exception_type`, `cause`, `is_fatal`) — the
+  /// backend `rum_crash_events` extractors read these verbatim. `cause` is a
+  /// clean fatal/non-fatal taxonomy (all Dart errors are `Error`/non-fatal); the
+  /// specific handler goes in the secondary `crash.source`. The client never
+  /// sends `crash_hash`/`severity`/`breadcrumbs` — the server derives those.
+  factory EdgeEvent.error(
+    Object error, {
+    StackTrace? stackTrace,
+    String? source,
+    Map<String, String>? attributes,
+  }) =>
+      EdgeEvent._crash({
+        'message': error.toString(),
+        if (stackTrace != null) 'stacktrace': stackTrace.toString(),
+        'exception_type': error.runtimeType.toString(),
+        'cause': 'Error',
+        'is_fatal': 'false',
+        if (source != null) 'crash.source': source,
+        ...?attributes,
+      });
+
+  const EdgeEvent._crash(this.attributes)
+      : type = 'event',
+        name = 'app.crash',
         value = null,
+        error = null,
+        stackTrace = null,
         countsToSession = false,
         priority = EventPriority.immediate;
 }

--- a/edge_telemetry_flutter/lib/src/core/retry_transport.dart
+++ b/edge_telemetry_flutter/lib/src/core/retry_transport.dart
@@ -68,13 +68,13 @@ class RetryTransport {
     final ok = await _sendRaw(crashData);
     if (ok) {
       // Error-report send logs are intentionally always printed (see CLAUDE.md).
-      print('✅ Error report sent successfully');
-      print('   📊 Error: ${crashData['error']}');
-      if (crashData['fingerprint'] != null) {
-        print('   🔍 Fingerprint: ${crashData['fingerprint']}');
-      }
       final attrs = crashData['attributes'];
+      print('✅ Error report sent successfully');
       if (attrs is Map) {
+        print('   📊 Error: ${attrs['message']}');
+        if (attrs['crash.source'] != null) {
+          print('   🎯 Source: ${attrs['crash.source']}');
+        }
         if (attrs['user.id'] != null) print('   👤 User: ${attrs['user.id']}');
         if (attrs['session.id'] != null) {
           print('   🔄 Session: ${attrs['session.id']}');

--- a/edge_telemetry_flutter/lib/src/crash/crash_reporting.dart
+++ b/edge_telemetry_flutter/lib/src/crash/crash_reporting.dart
@@ -1,43 +1,30 @@
 // lib/src/crash/crash_reporting.dart
 
 import '../core/edge_event.dart';
-import '../managers/breadcrumb_manager.dart';
 
-/// Builds the crash event: computes the grouping fingerprint and attaches the
-/// pre-crash breadcrumb ring, then hands an immediate-priority [EdgeEvent] to the
-/// [Collector] (which routes it down the one crash rail).
+/// The facade's crash seam: maps a Dart error + the catching handler into one
+/// immediate `app.crash` [EdgeEvent], then hands it to the [Collector] (which
+/// routes it down the crash rail).
+///
+/// Every handler — `FlutterError.onError`, `PlatformDispatcher.onError`,
+/// `runZonedGuarded`, the isolate error-listener, and host `trackError` —
+/// funnels here with its own [source] token (`flutter_error` /
+/// `platform_dispatcher` / `zone` / `isolate`), so `cause` stays a clean
+/// fatal/non-fatal taxonomy (`Error`, non-fatal) while the triage detail lives
+/// in the secondary `crash.source`. Payload keys are unprefixed and the client
+/// derives nothing (`crash_hash`/`severity`/`breadcrumbs` are server-computed)
+/// — the wire shape is owned by [EdgeEvent.error].
 class CrashReporting {
-  final BreadcrumbManager breadcrumbs;
+  const CrashReporting();
 
-  CrashReporting(this.breadcrumbs);
-
-  /// Fingerprint for grouping similar crashes: `ErrorType_msgHash_stackHash`.
-  String fingerprint(Object error, StackTrace? stackTrace) {
-    final errorType = error.runtimeType.toString();
-    final errorMessage = error.toString();
-    final topStackFrame = stackTrace?.toString().split('\n').firstWhere(
-              (line) => line.trim().isNotEmpty,
-              orElse: () => 'no_stack',
-            ) ??
-        'no_stack';
-    return '${errorType}_${errorMessage.hashCode}_${topStackFrame.hashCode}';
-  }
-
-  /// Build the enrichable crash event. Attribute order (breadcrumbs, then
-  /// `crash.fingerprint`, `crash.breadcrumb_count`, then caller attrs) is held
-  /// byte-identical with v1.5.2's `_getEnrichedAttributes` crash path.
+  /// Build the immediate `app.crash` event for [error]. [source] records the
+  /// catching handler; omit it for a host `trackError` with no specific origin.
   EdgeEvent buildCrashEvent(
     Object error, {
     StackTrace? stackTrace,
+    String? source,
     Map<String, String>? attributes,
-  }) {
-    final crumbs = breadcrumbs.getBreadcrumbsAsJson();
-    final attrs = <String, String>{
-      if (crumbs.isNotEmpty) 'breadcrumbs': crumbs.toString(),
-      'crash.fingerprint': fingerprint(error, stackTrace),
-      'crash.breadcrumb_count': crumbs.length.toString(),
-      ...?attributes,
-    };
-    return EdgeEvent.error(error, stackTrace: stackTrace, attributes: attrs);
-  }
+  }) =>
+      EdgeEvent.error(error,
+          stackTrace: stackTrace, source: source, attributes: attributes);
 }

--- a/edge_telemetry_flutter/lib/src/facade/edge_telemetry.dart
+++ b/edge_telemetry_flutter/lib/src/facade/edge_telemetry.dart
@@ -5,6 +5,7 @@
 // through the exports-only barrel (package:edge_telemetry_flutter/edge_telemetry_flutter.dart).
 
 import 'dart:io';
+import 'dart:isolate';
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
@@ -78,6 +79,9 @@ class EdgeTelemetry {
 
   bool _initialized = false;
   TelemetryConfig? _config;
+
+  // Kept so the isolate error-listener can be detached on dispose/hot-restart.
+  RawReceivePort? _isolateErrorPort;
 
   // ==================== INITIALIZATION ====================
 
@@ -244,15 +248,47 @@ class EdgeTelemetry {
     }
   }
 
+  /// Funnel every auto-catchable Dart error path into the one immediate
+  /// `app.crash` rail, each tagged with its `crash.source`. `runZonedGuarded`
+  /// (source `zone`) can't be retrofitted onto the already-running zone from
+  /// here — a consumer routes it via `trackError`; the source token is part of
+  /// the taxonomy for that path.
   void _installGlobalCrashHandler() {
     FlutterError.onError = (FlutterErrorDetails details) {
       FlutterError.presentError(details);
-      trackError(details.exception, stackTrace: details.stack);
+      _emitCrash(details.exception,
+          stackTrace: details.stack, source: 'flutter_error');
     };
     PlatformDispatcher.instance.onError = (error, stack) {
-      trackError(error, stackTrace: stack);
+      _emitCrash(error, stackTrace: stack, source: 'platform_dispatcher');
       return true;
     };
+
+    // Uncaught errors from the root isolate arrive as a 2-element list of
+    // strings [errorString, stackTraceString].
+    final port = RawReceivePort((dynamic message) {
+      final pair = (message as List).cast<String?>();
+      _emitCrash(
+        pair.isNotEmpty ? (pair[0] ?? 'Isolate error') : 'Isolate error',
+        stackTrace: (pair.length > 1 && pair[1] != null)
+            ? StackTrace.fromString(pair[1]!)
+            : null,
+        source: 'isolate',
+      );
+    });
+    Isolate.current.addErrorListener(port.sendPort);
+    _isolateErrorPort = port;
+  }
+
+  /// The one internal crash entry point — builds the `app.crash` event via
+  /// [CrashReporting] and hands it to the Collector's immediate rail.
+  void _emitCrash(Object error,
+      {StackTrace? stackTrace,
+      String? source,
+      Map<String, String>? attributes}) {
+    if (_wiring == null) return;
+    _wiring!.collector.add(_wiring!.crashReporting.buildCrashEvent(error,
+        stackTrace: stackTrace, source: source, attributes: attributes));
   }
 
   // ==================== CORE TRACKING API ====================
@@ -311,10 +347,7 @@ class EdgeTelemetry {
   void trackError(Object error,
       {StackTrace? stackTrace, Map<String, String>? attributes}) {
     _ensureInitialized();
-    _wiring!.collector.add(
-      _wiring!.crashReporting.buildCrashEvent(error,
-          stackTrace: stackTrace, attributes: attributes),
-    );
+    _emitCrash(error, stackTrace: stackTrace, attributes: attributes);
   }
 
   // ==================== DEPRECATED SPAN NO-OPS ====================
@@ -610,6 +643,12 @@ class EdgeTelemetry {
   /// Dispose all resources (call when the app is shutting down).
   void dispose() {
     _sessionManager?.endSession();
+
+    if (_isolateErrorPort != null) {
+      Isolate.current.removeErrorListener(_isolateErrorPort!.sendPort);
+      _isolateErrorPort!.close();
+      _isolateErrorPort = null;
+    }
 
     if (isLocalReportingEnabled && _currentSessionId != null) {
       _currentSession = _currentSession?.copyWith(endTime: DateTime.now());

--- a/edge_telemetry_flutter/lib/src/facade/telemetry_wiring.dart
+++ b/edge_telemetry_flutter/lib/src/facade/telemetry_wiring.dart
@@ -90,7 +90,7 @@ class TelemetryWiring {
       pipeline: pipeline,
     );
 
-    final crashReporting = CrashReporting(breadcrumbs);
+    const crashReporting = CrashReporting();
 
     final disposers = <DisposeHandle>[];
     NavCaptureHook? navHook;

--- a/edge_telemetry_flutter/test/unit/architecture/seams_test.dart
+++ b/edge_telemetry_flutter/test/unit/architecture/seams_test.dart
@@ -102,7 +102,7 @@ void main() {
         session: session,
         context: context,
         breadcrumbs: BreadcrumbManager(),
-        crashReporting: CrashReporting(BreadcrumbManager()),
+        crashReporting: const CrashReporting(),
         queue: queue,
         transport: transport,
         pipeline: pipeline,
@@ -224,7 +224,8 @@ void main() {
       collector.add(EdgeEvent.error(StateError('boom')));
       await Future<void>(() {});
       expect(sender.sent, hasLength(1)); // crash still sent
-      expect(sender.sent.single['type'], 'error');
+      expect(sender.sent.single['type'], 'event'); // immediate app.crash
+      expect(sender.sent.single['eventName'], 'app.crash');
     });
   });
 

--- a/edge_telemetry_flutter/test/unit/crash/crash_reporting_test.dart
+++ b/edge_telemetry_flutter/test/unit/crash/crash_reporting_test.dart
@@ -1,0 +1,138 @@
+// test/unit/crash/crash_reporting_test.dart
+//
+// Crash unification (#22): every Dart handler funnels into one immediate
+// `app.crash` event with unprefixed keys, `cause=Error`, `is_fatal=false`, and
+// the catching handler recorded in the secondary `crash.source`. Tests the
+// CrashReporting seam (cause + source + unprefixed payload) and end-to-end
+// immediate routing through Collector → Pipeline → transport.
+
+import 'package:edge_telemetry_flutter/src/core/collector.dart';
+import 'package:edge_telemetry_flutter/src/core/edge_event.dart';
+import 'package:edge_telemetry_flutter/src/core/offline_queue.dart';
+import 'package:edge_telemetry_flutter/src/core/pipeline.dart';
+import 'package:edge_telemetry_flutter/src/core/retry_transport.dart';
+import 'package:edge_telemetry_flutter/src/crash/crash_reporting.dart';
+import 'package:edge_telemetry_flutter/src/managers/context_manager.dart';
+import 'package:edge_telemetry_flutter/src/managers/session_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _RecordingSender {
+  final List<Map<String, dynamic>> sent = [];
+  Future<bool> call(Map<String, dynamic> payload) async {
+    sent.add(payload);
+    return true;
+  }
+}
+
+class _NoopQueue extends OfflineQueue {
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<String?> persist(Map<String, dynamic> p) async => null;
+  @override
+  Future<int> drain(Future<bool> Function(Map<String, dynamic>) s) async => 0;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  const reporting = CrashReporting();
+
+  group('buildCrashEvent — shape', () {
+    test('unprefixed keys, cause=Error, is_fatal=false, immediate app.crash',
+        () {
+      final event = reporting.buildCrashEvent(
+        StateError('boom'),
+        stackTrace: StackTrace.fromString('#0 main'),
+        source: 'flutter_error',
+      );
+
+      expect(event.type, 'event');
+      expect(event.name, 'app.crash');
+      expect(event.priority, EventPriority.immediate);
+      expect(event.countsToSession, isFalse);
+
+      final a = event.attributes;
+      expect(a['message'], 'Bad state: boom');
+      expect(a['exception_type'], 'StateError');
+      expect(a['stacktrace'], '#0 main');
+      expect(a['cause'], 'Error');
+      expect(a['is_fatal'], 'false');
+      expect(a['crash.source'], 'flutter_error');
+    });
+
+    test('records each handler in crash.source', () {
+      for (final source in [
+        'flutter_error',
+        'platform_dispatcher',
+        'zone',
+        'isolate',
+      ]) {
+        final e = reporting.buildCrashEvent(Exception('x'), source: source);
+        expect(e.attributes['crash.source'], source);
+        expect(e.attributes['cause'], 'Error'); // source never leaks into cause
+      }
+    });
+
+    test('no client-derived crash_hash / severity / breadcrumbs', () {
+      final a = reporting.buildCrashEvent(Exception('x')).attributes;
+      expect(a.containsKey('crash_hash'), isFalse);
+      expect(a.containsKey('crash.fingerprint'), isFalse);
+      expect(a.containsKey('severity'), isFalse);
+      expect(a.containsKey('breadcrumbs'), isFalse);
+    });
+
+    test('host trackError (no source) omits crash.source; caller attrs merge',
+        () {
+      final a = reporting.buildCrashEvent(
+        Exception('x'),
+        attributes: {'error.context': 'demo'},
+      ).attributes;
+      expect(a.containsKey('crash.source'), isFalse);
+      expect(a['error.context'], 'demo');
+    });
+
+    test('null stackTrace omits the stacktrace key', () {
+      final a = reporting.buildCrashEvent(Exception('x')).attributes;
+      expect(a.containsKey('stacktrace'), isFalse);
+    });
+  });
+
+  group('immediate routing', () {
+    Future<(Collector, _RecordingSender)> wire() async {
+      final sender = _RecordingSender();
+      final session = SessionManager();
+      await session.startSession('session_test');
+      final context = ContextManager(
+          sessionManager: session, global: {'device.id': 'device_x'});
+      final transport = RetryTransport(
+          endpoint: 'https://api.test', queue: _NoopQueue(), sender: sender.call);
+      // batchSize huge → a batched event would NOT flush; only the immediate
+      // rail can produce a send here.
+      final pipeline = Pipeline(transport: transport, batchSize: 999);
+      final collector =
+          Collector(context: context, session: session, pipeline: pipeline);
+      return (collector, sender);
+    }
+
+    test('crash bypasses the batch and sends immediately', () async {
+      final (collector, sender) = await wire();
+
+      collector.add(reporting.buildCrashEvent(StateError('boom'),
+          source: 'platform_dispatcher'));
+      await Future<void>(() {});
+
+      expect(sender.sent, hasLength(1));
+      final wireEvent = sender.sent.single;
+      expect(wireEvent['type'], 'event');
+      expect(wireEvent['eventName'], 'app.crash');
+      final attrs = wireEvent['attributes'] as Map;
+      expect(attrs['cause'], 'Error');
+      expect(attrs['is_fatal'], 'false');
+      expect(attrs['crash.source'], 'platform_dispatcher');
+      expect(attrs['device.id'], 'device_x'); // identity context folded in
+    });
+  });
+}

--- a/edge_telemetry_flutter/test/unit/crash/crash_reporting_test.dart
+++ b/edge_telemetry_flutter/test/unit/crash/crash_reporting_test.dart
@@ -108,7 +108,9 @@ void main() {
       final context = ContextManager(
           sessionManager: session, global: {'device.id': 'device_x'});
       final transport = RetryTransport(
-          endpoint: 'https://api.test', queue: _NoopQueue(), sender: sender.call);
+          endpoint: 'https://api.test',
+          queue: _NoopQueue(),
+          sender: sender.call);
       // batchSize huge → a batched event would NOT flush; only the immediate
       // rail can produce a send here.
       final pipeline = Pipeline(transport: transport, batchSize: 999);


### PR DESCRIPTION
Closes #22. Part of the atomic v2.0.0 (Spec #15, Phase 3). Blocked-by #21 (merged).

## What
Replace the bare `type:"error"` wire item with a single immediate **`app.crash`** event. Every Dart error path funnels through one shape.

- **Handlers → one event:** `FlutterError.onError`, `PlatformDispatcher.onError`, the now-wired **isolate error-listener**, and host `trackError` all produce `app.crash` with `cause="Error"`, `is_fatal="false"`.
- **Unprefixed payload keys:** `message`, `stacktrace`, `exception_type`, `cause`, `is_fatal` (backend `rum_crash_events` extractors read verbatim); the catching handler rides in the secondary `crash.source` (`flutter_error`/`platform_dispatcher`/`zone`/`isolate`), keeping `cause` a clean fatal/non-fatal taxonomy.
- **No client-derived fields:** `crash_hash`/`severity`/`breadcrumbs` are server-computed — breadcrumb + fingerprint machinery deleted from the crash path.
- **Immediate rail unchanged:** crashes bypass the batch and persist+drain on network failure.

## Changed
- `EdgeEvent.error` — factory owning the one `app.crash` wire shape (+ `source`)
- `Collector` — drop the `type:"error"` branch; route by priority, collapsing the per-type switch
- `CrashReporting` — stateless seam mapping handler→`crash.source`
- facade — tag sources, wire `Isolate.current` error-listener (detached on dispose), `_emitCrash` funnel
- `RetryTransport` — send-log reads the new attribute shape
- tests — new `crash_reporting_test.dart` (cause/source/unprefixed/immediate routing); seams updated

## Acceptance
- [x] All Dart handlers → single `app.crash`, `cause=Error`, `is_fatal=false`
- [x] Unprefixed payload keys; no client-derived `crash_hash`/`severity`/`breadcrumbs`
- [x] `crash.source` records the handler
- [x] Isolate error-listener wired
- [x] Immediate send bypasses batch; persist+drain on network failure
- [x] `CrashReporting` unit tests (cause + source + immediate routing)

## Notes
- `is_fatal` is a string `"false"` — consistent with the sibling native contract (`native_crash_channel.dart` sends `is_fatal="true"`; the whole `attributes` map is string-typed). The spec's JSON boolean is illustrative.
- `zone` source is a caller path, not auto-wired: `runAppCallback` was hard-removed in v2 and a zone can't be retrofitted from `initialize()`; `PlatformDispatcher.onError` catches what `runZonedGuarded` used to. The taxonomy value is supported and tested.
- README crash-section refresh deferred to the v2.0.0 migration-guide ticket (#49).

`flutter analyze` clean; full suite 43 pass.