### PR TITLE
wayfinder #23: offline queue + RetryTransport backoff (reliability rail)

### DIFF
--- a/edge_telemetry_flutter/CHANGELOG.md
+++ b/edge_telemetry_flutter/CHANGELOG.md
@@ -71,6 +71,18 @@ section below. Final version bump + migration guide land with the rest of v2.0.0
   flush). Old `eventBatchSize` / `batchTimeout` / `maxBatchSize` are deprecated
   (still honored as fallbacks, removed in v3.0.0).
 
+### 🛟 Reliability rail (Phase 3)
+- **ADDED**: normal batches now persist on send failure (was crash-only). The
+  `OfflineQueue` is one-file-per-batch under
+  `<app documents>/edge_telemetry_queue/` — the assembled payload is stored
+  verbatim, and draining lists files lexically (== FIFO), POSTs each, and
+  deletes on 2xx. No on-device dedup.
+- **ADDED**: `RetryTransport` batch backoff `[0, 2s, 8s, 30s]` — a reachable
+  failure exhausts the schedule before queueing; an offline result
+  (`status == 0`) hands off to the queue immediately.
+- **ADDED**: `maxQueueSize` config knob (default 200) — batches drop-oldest
+  past the cap; crashes (`crash_` filename prefix) are exempt and never dropped.
+
 ### 🧹 Internal
 - **REMOVED**: `opentelemetry` dependency, `SpanManager`, `EventTrackerImpl`,
   the `EventTracker` interface, and the `useJsonFormat` dual-backend branches.

--- a/edge_telemetry_flutter/lib/src/core/config/telemetry_config.dart
+++ b/edge_telemetry_flutter/lib/src/core/config/telemetry_config.dart
@@ -30,6 +30,10 @@ class TelemetryConfig {
   /// Idle time before a partial batch is sent, in ms (canon name; default 5s).
   final int flushIntervalMs;
 
+  /// Max batches held in the offline queue before drop-oldest kicks in.
+  /// Crashes (`crash_` prefix) are exempt and never dropped.
+  final int maxQueueSize;
+
   /// Batch timeout for sending telemetry data.
   @Deprecated('Use flushIntervalMs. Removed in v3.0.0.')
   final Duration batchTimeout;
@@ -83,6 +87,7 @@ class TelemetryConfig {
     this.globalAttributes = const {},
     this.batchSize = 30,
     this.flushIntervalMs = 5000,
+    this.maxQueueSize = 200,
     this.batchTimeout = const Duration(seconds: 5),
     this.maxBatchSize = 512,
     this.enableNetworkMonitoring = true,
@@ -108,6 +113,7 @@ class TelemetryConfig {
     Map<String, String>? globalAttributes,
     int? batchSize,
     int? flushIntervalMs,
+    int? maxQueueSize,
     Duration? batchTimeout,
     int? maxBatchSize,
     bool? enableNetworkMonitoring,
@@ -131,6 +137,7 @@ class TelemetryConfig {
       globalAttributes: globalAttributes ?? this.globalAttributes,
       batchSize: batchSize ?? this.batchSize,
       flushIntervalMs: flushIntervalMs ?? this.flushIntervalMs,
+      maxQueueSize: maxQueueSize ?? this.maxQueueSize,
       // ignore: deprecated_member_use_from_same_package
       batchTimeout: batchTimeout ?? this.batchTimeout,
       // ignore: deprecated_member_use_from_same_package

--- a/edge_telemetry_flutter/lib/src/core/offline_queue.dart
+++ b/edge_telemetry_flutter/lib/src/core/offline_queue.dart
@@ -8,24 +8,31 @@ import 'package:path_provider/path_provider.dart';
 /// FIFO on-disk queue for telemetry that failed to send.
 ///
 /// One file per payload under `<app documents>/edge_telemetry_queue/`. Draining
-/// lists the files in lexical (== chronological, timestamp-named) order, POSTs
-/// each via the caller-supplied sender, and deletes on success. The stored bytes
-/// are the assembled payload verbatim, so a drained retry is byte-identical to
-/// the original send.
+/// lists the files in lexical order, POSTs each via the caller-supplied sender,
+/// and deletes on success. Filenames are timestamp-named, so lexical order is
+/// chronological *within* a prefix; the two prefixes below drain as a group
+/// (`batch_` before `crash_`), which is enough — both are sent, and cross-kind
+/// ordering isn't load-bearing. The stored bytes are the assembled payload
+/// verbatim, so a drained retry is byte-identical to the original send.
 ///
-/// Absorbs the v1.5.2 `CrashStorage` — the single unified persistence rail.
-// ponytail: crash-only in Phase 2 (only the crash rail persists on failure).
-// Normal-batch persistence + the ~200 drop-oldest cap + crash-exempt policy are
-// reliability work owned by #9. Drop-oldest is kept at the old 100 for parity.
+/// Two filename prefixes: `batch_` for normal batches (subject to the
+/// [maxQueueSize] drop-oldest cap) and `crash_` for crashes (exempt from the
+/// cap — a crash is never dropped). Absorbs the v1.5.2 `CrashStorage`.
 class OfflineQueue {
   static const String _queueDir = 'edge_telemetry_queue';
-  static const String _filePrefix = 'crash_';
-  static const int _maxStored = 100;
+  static const String _batchPrefix = 'batch_';
+  static const String _crashPrefix = 'crash_';
+
+  /// Monotonic tiebreak so two persists in the same millisecond keep a stable
+  /// lexical (== insertion) order instead of colliding on one filename.
+  static int _seq = 0;
 
   final bool _debugMode;
+  final int maxQueueSize;
   Directory? _dir;
 
-  OfflineQueue({bool debugMode = false}) : _debugMode = debugMode;
+  OfflineQueue({bool debugMode = false, this.maxQueueSize = 200})
+      : _debugMode = debugMode;
 
   Future<void> initialize() async {
     try {
@@ -40,15 +47,19 @@ class OfflineQueue {
   }
 
   /// Persist a payload for later drain. Returns the filename, or null on failure.
-  Future<String?> persist(Map<String, dynamic> payload) async {
+  /// [isCrash] files use the `crash_` prefix and are exempt from the size cap.
+  Future<String?> persist(Map<String, dynamic> payload,
+      {bool isCrash = false}) async {
     if (_dir == null) await initialize();
     if (_dir == null) return null;
 
     try {
+      final prefix = isCrash ? _crashPrefix : _batchPrefix;
       final timestamp = DateTime.now().millisecondsSinceEpoch;
-      final filename = '$_filePrefix$timestamp.json';
+      final seq = (_seq++).toString().padLeft(6, '0');
+      final filename = '$prefix${timestamp}_$seq.json';
       await File('${_dir!.path}/$filename').writeAsString(jsonEncode(payload));
-      await _enforceCap();
+      if (!isCrash) await _enforceCap();
       if (_debugMode) print('💾 Persisted payload to offline queue: $filename');
       return filename;
     } catch (e) {
@@ -88,18 +99,27 @@ class OfflineQueue {
   Future<List<File>> _queueFiles() async {
     return _dir!
         .list()
-        .where((e) => e is File && e.path.contains(_filePrefix))
+        .where((e) => e is File && _isQueueFile(e))
         .cast<File>()
         .toList();
   }
 
-  /// Drop the oldest files once the queue exceeds the cap.
+  bool _isQueueFile(File f) {
+    final name = f.uri.pathSegments.last;
+    return name.endsWith('.json') &&
+        (name.startsWith(_batchPrefix) || name.startsWith(_crashPrefix));
+  }
+
+  bool _isCrash(File f) => f.uri.pathSegments.last.startsWith(_crashPrefix);
+
+  /// Drop the oldest batch files once they exceed [maxQueueSize]. Crash files
+  /// are exempt — they never count toward the cap and are never dropped.
   Future<void> _enforceCap() async {
     try {
-      final files = await _queueFiles();
-      if (files.length <= _maxStored) return;
-      files.sort((a, b) => a.path.compareTo(b.path));
-      for (final file in files.take(files.length - _maxStored)) {
+      final batches = (await _queueFiles()).where((f) => !_isCrash(f)).toList();
+      if (batches.length <= maxQueueSize) return;
+      batches.sort((a, b) => a.path.compareTo(b.path));
+      for (final file in batches.take(batches.length - maxQueueSize)) {
         await file.delete();
       }
     } catch (e) {

--- a/edge_telemetry_flutter/lib/src/core/retry_transport.dart
+++ b/edge_telemetry_flutter/lib/src/core/retry_transport.dart
@@ -8,8 +8,19 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'offline_queue.dart';
 
 /// Low-level POST primitive. Returns true on a 2xx response. Injectable so tests
-/// can drive the transport without real network I/O.
+/// can drive the transport without real network I/O. A `false` return is treated
+/// as a reachable HTTP failure (exercises the backoff path); the offline
+/// (`status == 0`, immediate-queue) path is only reachable via real HTTP.
 typedef Sender = Future<bool> Function(Map<String, dynamic> payload);
+
+/// Backoff schedule for a batch send: attempt, then wait each delay before the
+/// next retry, then queue. `[0, 2s, 8s, 30s]` = 4 attempts (family canon).
+const List<Duration> kDefaultBackoff = [
+  Duration.zero,
+  Duration(seconds: 2),
+  Duration(seconds: 8),
+  Duration(seconds: 30),
+];
 
 /// The single network rail: POSTs assembled payloads and, for the crash path,
 /// persists to the [OfflineQueue] on failure and drains it on reconnect.
@@ -21,6 +32,7 @@ class RetryTransport {
   final String? apiKey;
   final OfflineQueue queue;
   final bool debugMode;
+  final List<Duration> backoff;
 
   final HttpClient _httpClient;
   final Sender? _sender;
@@ -34,6 +46,7 @@ class RetryTransport {
     required this.queue,
     this.apiKey,
     this.debugMode = false,
+    this.backoff = kDefaultBackoff,
     HttpClient? httpClient,
     Sender? sender,
   })  : _httpClient = httpClient ?? HttpClient(),
@@ -52,20 +65,28 @@ class RetryTransport {
     return Uri.parse('$base/collector/telemetry');
   }
 
-  /// Send a batch. Byte-identical to v1.5.2 `JsonHttpClient.sendTelemetryData`.
-  /// On success, opportunistically drains any queued crash payloads.
-  // ponytail: normal-batch failures are dropped (not persisted), matching
-  // v1.5.2. Persisting normal batches is reliability work owned by #9.
+  /// Send a batch. Exhaust the [backoff] schedule before giving up; on the last
+  /// failure persist the batch verbatim for a later drain. An offline result
+  /// (`status == 0`) skips the remaining backoff and queues immediately. On any
+  /// success, opportunistically drains the queue.
   Future<bool> send(Map<String, dynamic> batch) async {
-    final ok = await _sendRaw(batch);
-    if (ok) await drainQueue();
-    return ok;
+    for (var i = 0; i < backoff.length; i++) {
+      if (backoff[i] > Duration.zero) await Future.delayed(backoff[i]);
+      final status = await _status(batch);
+      if (_ok(status)) {
+        await drainQueue();
+        return true;
+      }
+      if (status == 0) break; // offline — don't burn backoff, queue now
+    }
+    await queue.persist(batch);
+    return false;
   }
 
   /// Send a crash immediately, bypassing the batch. On failure, persist to the
   /// offline queue so a crash that kills the app still arrives on next launch.
   Future<void> sendImmediate(Map<String, dynamic> crashData) async {
-    final ok = await _sendRaw(crashData);
+    final ok = _ok(await _status(crashData));
     if (ok) {
       // Error-report send logs are intentionally always printed (see CLAUDE.md).
       final attrs = crashData['attributes'];
@@ -84,7 +105,7 @@ class RetryTransport {
       await drainQueue();
     } else {
       print('❌ Failed to send error report, storing offline');
-      final filename = await queue.persist(crashData);
+      final filename = await queue.persist(crashData, isCrash: true);
       if (filename != null) {
         print('💾 Error report stored for retry: $filename');
       }
@@ -92,16 +113,21 @@ class RetryTransport {
   }
 
   /// Drain queued payloads through the same POST primitive.
-  Future<void> drainQueue() => queue.drain(_sendRaw);
+  Future<void> drainQueue() =>
+      queue.drain((data) async => _ok(await _status(data)));
 
-  /// The one POST primitive. Injected [Sender] wins (tests); otherwise real HTTP.
-  Future<bool> _sendRaw(Map<String, dynamic> data) {
+  bool _ok(int status) => status >= 200 && status < 300;
+
+  /// One send attempt → HTTP status. Injected [Sender] wins (tests): `true`→200,
+  /// `false`→500 (a reachable failure). Real HTTP returns the status, or 0 when
+  /// the connection can't be made (offline).
+  Future<int> _status(Map<String, dynamic> data) async {
     final sender = _sender;
-    if (sender != null) return sender(data);
+    if (sender != null) return (await sender(data)) ? 200 : 500;
     return _httpPost(data);
   }
 
-  Future<bool> _httpPost(Map<String, dynamic> data) async {
+  Future<int> _httpPost(Map<String, dynamic> data) async {
     try {
       final request = await _httpClient.postUrl(_url);
       request.headers.set('Content-Type', 'application/json');
@@ -111,13 +137,13 @@ class RetryTransport {
 
       if (response.statusCode >= 200 && response.statusCode < 300) {
         print('✅ Sent telemetry data successfully');
-        return true;
+      } else {
+        print('❌ Failed: HTTP ${response.statusCode}');
       }
-      print('❌ Failed: HTTP ${response.statusCode}');
-      return false;
+      return response.statusCode;
     } catch (e) {
       print('❌ Error: $e');
-      return false;
+      return 0; // offline / no connection
     }
   }
 

--- a/edge_telemetry_flutter/lib/src/facade/telemetry_wiring.dart
+++ b/edge_telemetry_flutter/lib/src/facade/telemetry_wiring.dart
@@ -65,7 +65,8 @@ class TelemetryWiring {
     required ContextManager context,
     required BreadcrumbManager breadcrumbs,
   }) async {
-    final queue = OfflineQueue(debugMode: config.debugMode);
+    final queue = OfflineQueue(
+        debugMode: config.debugMode, maxQueueSize: config.maxQueueSize);
     await queue.initialize();
 
     final transport = RetryTransport(

--- a/edge_telemetry_flutter/pubspec.lock
+++ b/edge_telemetry_flutter/pubspec.lock
@@ -329,7 +329,7 @@ packages:
     source: hosted
     version: "2.2.1"
   path_provider_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: path_provider_platform_interface
       sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
@@ -361,7 +361,7 @@ packages:
     source: hosted
     version: "3.1.6"
   plugin_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"

--- a/edge_telemetry_flutter/pubspec.yaml
+++ b/edge_telemetry_flutter/pubspec.yaml
@@ -22,5 +22,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^3.0.0
+  # Test-only: fake the docs dir so the OfflineQueue disk seam runs on a temp dir.
+  path_provider_platform_interface: ^2.1.0
+  plugin_platform_interface: ^2.1.0
 
 flutter:

--- a/edge_telemetry_flutter/test/unit/architecture/seams_test.dart
+++ b/edge_telemetry_flutter/test/unit/architecture/seams_test.dart
@@ -46,7 +46,8 @@ class _FakeQueue extends OfflineQueue {
   Future<void> initialize() async {}
 
   @override
-  Future<String?> persist(Map<String, dynamic> payload) async {
+  Future<String?> persist(Map<String, dynamic> payload,
+      {bool isCrash = false}) async {
     persisted.add(payload);
     pending.add(payload);
     return 'fake_${persisted.length}.json';

--- a/edge_telemetry_flutter/test/unit/core/offline_queue_test.dart
+++ b/edge_telemetry_flutter/test/unit/core/offline_queue_test.dart
@@ -1,0 +1,119 @@
+// test/unit/core/offline_queue_test.dart
+//
+// Reliability-rail seams (#23): file-per-batch persist, lexical FIFO drain,
+// verbatim bytes, ~cap drop-oldest, and the crash-exempt policy. Runs against a
+// real temp dir via a faked PathProviderPlatform — no mocking of the queue.
+
+import 'dart:io';
+
+import 'package:edge_telemetry_flutter/src/core/offline_queue.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+/// Points `getApplicationDocumentsDirectory()` at a real temp dir.
+class _FakePathProvider extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  _FakePathProvider(this.docsPath);
+  final String docsPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => docsPath;
+}
+
+void main() {
+  late Directory docs;
+
+  setUp(() async {
+    docs = await Directory.systemTemp.createTemp('edge_queue_test');
+    PathProviderPlatform.instance = _FakePathProvider(docs.path);
+  });
+
+  tearDown(() async {
+    if (await docs.exists()) await docs.delete(recursive: true);
+  });
+
+  Future<List<String>> queuedFiles() async {
+    final dir = Directory('${docs.path}/edge_telemetry_queue');
+    if (!await dir.exists()) return [];
+    return dir
+        .listSync()
+        .whereType<File>()
+        .map((f) => f.uri.pathSegments.last)
+        .toList()
+      ..sort();
+  }
+
+  test('persists one file per batch, bytes verbatim', () async {
+    final q = OfflineQueue();
+    await q.persist({'type': 'telemetry_batch', 'events': []});
+
+    final files = await queuedFiles();
+    expect(files, hasLength(1));
+    expect(files.single, startsWith('batch_'));
+
+    final content =
+        await File('${docs.path}/edge_telemetry_queue/${files.single}')
+            .readAsString();
+    expect(content, '{"type":"telemetry_batch","events":[]}');
+  });
+
+  test('drains FIFO in lexical order and deletes on success', () async {
+    final q = OfflineQueue();
+    for (var i = 0; i < 3; i++) {
+      await q.persist({'n': i});
+    }
+
+    final drained = <int>[];
+    final count = await q.drain((p) async {
+      drained.add(p['n'] as int);
+      return true; // 2xx
+    });
+
+    expect(count, 3);
+    expect(drained, [0, 1, 2]); // FIFO
+    expect(await queuedFiles(), isEmpty); // deleted on 2xx
+  });
+
+  test('keeps files whose send fails (no delete on non-2xx)', () async {
+    final q = OfflineQueue();
+    await q.persist({'n': 0});
+
+    final count = await q.drain((_) async => false);
+    expect(count, 0);
+    expect(await queuedFiles(), hasLength(1));
+  });
+
+  test('cap drops oldest batches beyond maxQueueSize', () async {
+    final q = OfflineQueue(maxQueueSize: 3);
+    for (var i = 0; i < 6; i++) {
+      await q.persist({'n': i});
+    }
+
+    final surviving = <int>[];
+    await q.drain((p) async {
+      surviving.add(p['n'] as int);
+      return true;
+    });
+
+    expect(surviving, hasLength(3));
+    expect(surviving, [3, 4, 5]); // oldest three dropped
+  });
+
+  test('crashes are exempt from the cap', () async {
+    final q = OfflineQueue(maxQueueSize: 2);
+    for (var i = 0; i < 5; i++) {
+      await q.persist({'c': i}, isCrash: true);
+    }
+    // A couple of normal batches alongside the crashes.
+    await q.persist({'b': 0});
+    await q.persist({'b': 1});
+    await q.persist({'b': 2}); // trips the cap → drops oldest batch
+
+    final files = await queuedFiles();
+    final crashes = files.where((f) => f.startsWith('crash_'));
+    final batches = files.where((f) => f.startsWith('batch_'));
+    expect(crashes, hasLength(5)); // all crashes kept
+    expect(batches, hasLength(2)); // batches capped at 2
+  });
+}

--- a/edge_telemetry_flutter/test/unit/core/retry_transport_test.dart
+++ b/edge_telemetry_flutter/test/unit/core/retry_transport_test.dart
@@ -1,0 +1,101 @@
+// test/unit/core/retry_transport_test.dart
+//
+// Reliability-rail seams (#23): the [0,2s,8s,30s] backoff-then-queue on a
+// reachable failure, immediate queue when offline (status==0), and the
+// X-API-Key header on the real POST.
+
+import 'dart:io';
+
+import 'package:edge_telemetry_flutter/src/core/offline_queue.dart';
+import 'package:edge_telemetry_flutter/src/core/retry_transport.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// In-memory queue that records what got persisted — no disk, no path_provider.
+class _RecordingQueue extends OfflineQueue {
+  final List<Map<String, dynamic>> persisted = [];
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<String?> persist(Map<String, dynamic> payload,
+      {bool isCrash = false}) async {
+    persisted.add(payload);
+    return 'rec_${persisted.length}.json';
+  }
+
+  @override
+  Future<int> drain(Future<bool> Function(Map<String, dynamic>) send) async =>
+      0;
+}
+
+void main() {
+  test('reachable failure exhausts the backoff, then queues the batch',
+      () async {
+    final queue = _RecordingQueue();
+    var attempts = 0;
+    final transport = RetryTransport(
+      endpoint: 'https://example.test',
+      queue: queue,
+      backoff: const [Duration.zero, Duration.zero, Duration.zero],
+      sender: (_) async {
+        attempts++;
+        return false; // reachable failure (500)
+      },
+    );
+
+    final ok = await transport.send({'type': 'telemetry_batch'});
+
+    expect(ok, isFalse);
+    expect(attempts, 3); // all backoff slots tried
+    expect(queue.persisted, hasLength(1)); // queued after exhaustion
+  });
+
+  test('offline (status==0) queues immediately without burning backoff',
+      () async {
+    final queue = _RecordingQueue();
+    // Port 1 refuses the connection → real HTTP path returns status 0.
+    final transport = RetryTransport(
+      endpoint: 'http://localhost:1',
+      queue: queue,
+      // Long delays that must NOT be awaited if the offline shortcut works.
+      backoff: const [Duration.zero, Duration(seconds: 30)],
+    );
+
+    final sw = Stopwatch()..start();
+    final ok = await transport.send({'type': 'telemetry_batch'});
+    sw.stop();
+
+    expect(ok, isFalse);
+    expect(queue.persisted, hasLength(1));
+    expect(sw.elapsed, lessThan(const Duration(seconds: 5))); // no 30s wait
+  });
+
+  test('sends the X-API-Key header on the real POST', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    String? seenKey;
+    String? seenPath;
+    server.listen((req) async {
+      seenKey = req.headers.value('X-API-Key');
+      seenPath = req.uri.path;
+      await req.drain<void>();
+      req.response.statusCode = 200;
+      await req.response.close();
+    });
+    addTearDown(() => server.close(force: true));
+
+    final queue = _RecordingQueue();
+    final transport = RetryTransport(
+      endpoint: 'http://${server.address.host}:${server.port}',
+      apiKey: 'secret-123',
+      queue: queue,
+    );
+
+    final ok = await transport.send({'type': 'telemetry_batch', 'events': []});
+
+    expect(ok, isTrue);
+    expect(seenKey, 'secret-123');
+    expect(seenPath, '/collector/telemetry');
+    expect(queue.persisted, isEmpty); // success → nothing queued
+  });
+}

--- a/edge_telemetry_flutter/test/unit/core/wire_flip_test.dart
+++ b/edge_telemetry_flutter/test/unit/core/wire_flip_test.dart
@@ -30,7 +30,9 @@ class _NoopQueue extends OfflineQueue {
   @override
   Future<void> initialize() async {}
   @override
-  Future<String?> persist(Map<String, dynamic> p) async => null;
+  Future<String?> persist(Map<String, dynamic> p,
+          {bool isCrash = false}) async =>
+      null;
   @override
   Future<int> drain(Future<bool> Function(Map<String, dynamic>) s) async => 0;
 }

--- a/edge_telemetry_flutter/test/unit/crash/crash_reporting_test.dart
+++ b/edge_telemetry_flutter/test/unit/crash/crash_reporting_test.dart
@@ -29,7 +29,9 @@ class _NoopQueue extends OfflineQueue {
   @override
   Future<void> initialize() async {}
   @override
-  Future<String?> persist(Map<String, dynamic> p) async => null;
+  Future<String?> persist(Map<String, dynamic> p,
+          {bool isCrash = false}) async =>
+      null;
   @override
   Future<int> drain(Future<bool> Function(Map<String, dynamic>) s) async => 0;
 }


### PR DESCRIPTION
Closes #23. Parent: Spec #15 (v2.0.0, Phase 3). Builds on #21.

## What
Extends the crash-only persistence rail (#21) into the general **reliability rail** — normal batches now persist on send failure, not just crashes.

- **`OfflineQueue`** — `batch_` prefix for normal batches (subject to the drop-oldest cap), `crash_` for crashes (exempt, never dropped). Verbatim persist, lexical-FIFO drain, delete-on-2xx. Monotonic seq suffix avoids same-ms filename collisions.
- **`RetryTransport`** — batch send exhausts the `[0, 2s, 8s, 30s]` backoff before queueing; an offline result (`status == 0`) hands off to the queue immediately. Injectable backoff for fast tests; `Sender` typedef unchanged (no ripple).
- **Config** — new `maxQueueSize` knob (default 200), threaded through `copyWith` + `TelemetryWiring`.

## Acceptance criteria
- [x] File-per-batch queue; verbatim persist; lexical-sort FIFO drain; delete on 2xx
- [x] Cap ~200 drop-oldest; `crash_` prefix exempt from cap
- [x] Retry `[0,2s,8s,30s]` then queue; immediate queue on offline/`status==0`
- [x] No dedup; `maxQueueSize` knob
- [x] `OfflineQueue` + `RetryTransport` seam tests (persist / FIFO drain / cap / crash-exempt / `X-API-Key`)

## Tests
8 new seam tests — real temp-dir queue (persist/FIFO/cap/crash-exempt via faked `PathProviderPlatform`) and transport backoff/offline/X-API-Key via a local `HttpServer`. Full suite **51 passing**, `flutter analyze` clean.

## Review
Two-axis code-review (Standards + Spec) run — no hard violations, all 5 criteria met. Applied both cheap fixes surfaced: scoped the queue file glob to the `batch_`/`crash_` prefixes, and corrected the cross-prefix FIFO comment.