### PR TITLE
wayfinder #24: timer-free lazy session model + journey summary

### DIFF
--- a/edge_telemetry_flutter/lib/src/capture/lifecycle_capture_hook.dart
+++ b/edge_telemetry_flutter/lib/src/capture/lifecycle_capture_hook.dart
@@ -1,0 +1,52 @@
+// lib/src/capture/lifecycle_capture_hook.dart
+
+import 'package:flutter/widgets.dart';
+
+import '../core/edge_event.dart';
+import '../managers/session_manager.dart';
+import 'capture_hook.dart';
+
+/// Bridges `AppLifecycleState` to the session model (spec #15 §2.2) and emits
+/// the canon `app_lifecycle` event.
+///
+/// - `paused`: emit the lifecycle event, **flush** the Pipeline (nothing lost to
+///   a subsequent kill), then [SessionManager.handlePause] (mark, don't
+///   finalize).
+/// - `resumed`: [SessionManager.handleResume] first (rotate if idle past the
+///   window) so the lifecycle event lands on the correct session.
+class LifecycleCaptureHook with WidgetsBindingObserver implements CaptureHook {
+  final SessionManager session;
+
+  /// Flushes the Pipeline buffer (wired to `pipeline.flush`).
+  final void Function() flush;
+
+  EventSink? _sink;
+
+  LifecycleCaptureHook({required this.session, required this.flush});
+
+  @override
+  DisposeHandle start(EventSink sink) {
+    _sink = sink;
+    WidgetsBinding.instance.addObserver(this);
+    return () => WidgetsBinding.instance.removeObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.paused) {
+      _emit(state);
+      flush();
+      session.handlePause();
+    } else if (state == AppLifecycleState.resumed) {
+      session.handleResume();
+      _emit(state);
+    } else {
+      _emit(state);
+    }
+  }
+
+  void _emit(AppLifecycleState state) =>
+      _sink?.add(EdgeEvent.event('app_lifecycle', attributes: {
+        'lifecycle.state': state.name,
+      }));
+}

--- a/edge_telemetry_flutter/lib/src/core/collector.dart
+++ b/edge_telemetry_flutter/lib/src/core/collector.dart
@@ -35,6 +35,11 @@ class Collector implements EventSink {
 
   @override
   void add(EdgeEvent event) {
+    // Lazy idle check on the "next event" (spec #15 §2.1): may rotate the
+    // session (finalize old + start new) before this event is processed.
+    // Guarded internally against the bookends it re-emits here.
+    session.beforeEvent();
+
     if (!_shouldSample(event)) return;
 
     // Allowlist gate: only the canon 12 events / 4 metrics reach the wire.
@@ -49,6 +54,16 @@ class Collector implements EventSink {
     // include itself (matches v1.5.2 recordEvent-before-enrich ordering).
     if (event.countsToSession) {
       event.type == 'metric' ? session.recordMetric() : session.recordEvent();
+    }
+
+    // Journey counters by canon name (§2.3). app.crash counts as a crash, and
+    // as a non-fatal error when is_fatal=false (all Dart errors); http.request
+    // counts an HTTP hit. These feed the session.finalized summary.
+    if (event.name == 'app.crash') {
+      session.recordCrash();
+      if (event.attributes['is_fatal'] == 'false') session.recordError();
+    } else if (event.name == 'http.request') {
+      session.recordHttpRequest();
     }
 
     // The single wire choke point for the geo/tenant strip: every path below

--- a/edge_telemetry_flutter/lib/src/core/edge_event.dart
+++ b/edge_telemetry_flutter/lib/src/core/edge_event.dart
@@ -95,4 +95,17 @@ class EdgeEvent {
         stackTrace = null,
         countsToSession = false,
         priority = EventPriority.immediate;
+
+  /// The session bookends (`session.started` / `session.finalized`). Immediate
+  /// rail + bypass: they always reach the wire (never batched away, never
+  /// sampled out — a sampled-out session must still bracket itself) and never
+  /// bump the session counters. Attributes are carried verbatim (the finalize
+  /// journey summary is pre-built by [SessionManager]).
+  const EdgeEvent.session(this.name, this.attributes)
+      : type = 'event',
+        value = null,
+        error = null,
+        stackTrace = null,
+        countsToSession = false,
+        priority = EventPriority.immediate;
 }

--- a/edge_telemetry_flutter/lib/src/facade/edge_telemetry.dart
+++ b/edge_telemetry_flutter/lib/src/facade/edge_telemetry.dart
@@ -164,9 +164,10 @@ class EdgeTelemetry {
       _userIdManager = UserIdManager();
       _currentUserId = await _userIdManager!.getUserId();
 
-      _sessionManager = SessionManager();
-      _currentSessionId = _generateSessionId();
-      await _sessionManager!.startSession(_currentSessionId!);
+      // Timer-free lazy session model. The session is started *after* the
+      // wiring is built (below) so `recoverAndStart` can emit session.started
+      // (and any backdated kill-recovery finalize) through the Collector.
+      _sessionManager = SessionManager(newSessionId: _generateSessionId);
 
       await _loadProfileVersion();
 
@@ -182,13 +183,17 @@ class EdgeTelemetry {
         global: _globalAttributes,
       );
 
-      // Build + start the graph.
+      // Build + start the graph (binds the session bookend sink to the
+      // Collector), then recover any killed prior session and start a fresh one.
       _wiring = await TelemetryWiring.build(
         config: config,
         session: _sessionManager!,
         context: context,
         breadcrumbs: breadcrumbs,
       );
+
+      await _sessionManager!.recoverAndStart();
+      _currentSessionId = _sessionManager!.currentSessionId;
 
       if (config.enableCrashReporting) {
         _installGlobalCrashHandler();

--- a/edge_telemetry_flutter/lib/src/facade/telemetry_wiring.dart
+++ b/edge_telemetry_flutter/lib/src/facade/telemetry_wiring.dart
@@ -2,6 +2,7 @@
 
 import '../capture/capture_hook.dart';
 import '../capture/http_capture_hook.dart';
+import '../capture/lifecycle_capture_hook.dart';
 import '../capture/nav_capture_hook.dart';
 import '../capture/network_capture_hook.dart';
 import '../capture/perf_capture_hook.dart';
@@ -91,6 +92,11 @@ class TelemetryWiring {
       pipeline: pipeline,
     );
 
+    // Late-bind the session bookend sink now the Collector exists (breaks the
+    // session↔collector construction cycle). session.started/finalized route
+    // here from now on.
+    session.bindSink(collector);
+
     const crashReporting = CrashReporting();
 
     final disposers = <DisposeHandle>[];
@@ -112,6 +118,14 @@ class TelemetryWiring {
       navHook = NavCaptureHook(session: session, breadcrumbs: breadcrumbs);
       disposers.add(navHook.start(collector));
     }
+
+    // The lifecycle→session bridge (paused=flush+mark, resume=rotate-if-idle)
+    // plus the canon app_lifecycle event. Always on — it drives the session
+    // model, not an optional monitor.
+    disposers.add(
+      LifecycleCaptureHook(session: session, flush: pipeline.flush)
+          .start(collector),
+    );
 
     return TelemetryWiring(
       config: config,

--- a/edge_telemetry_flutter/lib/src/managers/session_manager.dart
+++ b/edge_telemetry_flutter/lib/src/managers/session_manager.dart
@@ -1,55 +1,301 @@
+import 'dart:convert';
+
 import 'package:shared_preferences/shared_preferences.dart';
 
-/// Manages session lifecycle and provides session context for telemetry
+import '../capture/capture_hook.dart' show EventSink;
+import '../core/edge_event.dart';
+
+/// Timer-free lazy session model (spec #15 §2 / ticket #24).
+///
+/// A session rotates only on the **30-minute idle rule**, evaluated lazily on
+/// the next event ([beforeEvent]) or on [handleResume] — never on a
+/// `Timer.periodic` (a backgrounded Flutter app can't run timers). `paused`
+/// flushes and marks (see [handlePause]); the finalize is deferred to
+/// resume-after-idle, the next in-app rotation, or the next launch
+/// ([recoverAndStart]) — always **backdated** to the last activity.
+///
+/// `session.id` + the running counters are persisted to `shared_preferences`
+/// so a killed app still finalizes its last session on the following launch.
 class SessionManager {
+  // Legacy keys (kept for is-first/total-sessions attributes).
   static const String _sessionCountKey = 'edge_telemetry_session_count';
   static const String _firstSessionKey = 'edge_telemetry_first_session';
 
-  String? _currentSessionId;
-  DateTime? _sessionStartTime;
+  // The kill-recovery record: the one not-yet-finalized session, as JSON.
+  static const String _recordKey = 'edge_telemetry_session_record';
+
+  /// Where `session.started` / `session.finalized` go (the Collector). Null in
+  /// state-only tests → bookends are simply not emitted.
+  void Function(EdgeEvent event)? _emit;
+
+  /// New session id minter (the facade injects the family-format generator).
+  final String Function() _newId;
+
+  /// Injectable clock — tests advance it to exercise idle rotation.
+  final DateTime Function() _clock;
+
+  /// Idle window after which the next activity rotates the session.
+  final Duration idleTimeout;
+
   SharedPreferences? _prefs;
 
-  // Session counters
+  String? _currentSessionId;
+  DateTime? _sessionStartTime;
+  DateTime? _lastActivityAt;
+  bool _rotating = false;
+
+  // Journey counters.
   int _eventCount = 0;
   int _metricCount = 0;
+  int _errorCount = 0;
+  int _crashCount = 0;
+  int _httpRequestCount = 0;
   final Set<String> _visitedScreens = {};
+  final List<String> _screenJourney = [];
 
-  /// Start a new session
-  Future<void> startSession(String sessionId) async {
-    _currentSessionId = sessionId;
-    _sessionStartTime = DateTime.now();
+  SessionManager({
+    void Function(EdgeEvent event)? emit,
+    String Function()? newSessionId,
+    DateTime Function()? clock,
+    this.idleTimeout = const Duration(minutes: 30),
+    SharedPreferences? prefs,
+  })  : _emit = emit,
+        _newId = newSessionId ??
+            (() => 'session_${DateTime.now().millisecondsSinceEpoch}'),
+        _clock = clock ?? DateTime.now,
+        _prefs = prefs;
 
-    // Reset counters
-    _eventCount = 0;
-    _metricCount = 0;
-    _visitedScreens.clear();
+  /// Late-bind the sink once the Collector exists (breaks the session↔collector
+  /// construction cycle). Called by `TelemetryWiring.build`.
+  void bindSink(EventSink sink) => _emit = sink.add;
 
-    // Update session count in storage
+  // ==================== LIFECYCLE ====================
+
+  /// Init-time entry: finalize any persisted (killed) prior session backdated to
+  /// its last activity, then start a fresh one. Emits at most one
+  /// `session.finalized` + one `session.started`.
+  Future<void> recoverAndStart() async {
     _prefs ??= await SharedPreferences.getInstance();
-    final sessionCount = (_prefs!.getInt(_sessionCountKey) ?? 0) + 1;
-    await _prefs!.setInt(_sessionCountKey, sessionCount);
+    final raw = _prefs!.getString(_recordKey);
+    if (raw != null) {
+      _emitFinalizeFromRecord(raw);
+    }
+    _beginSession(_newId());
+  }
 
-    // Mark first session flag
-    if (sessionCount == 1) {
-      await _prefs!.setBool(_firstSessionKey, true);
+  /// Legacy/explicit start with a caller-supplied id (used by existing seam
+  /// tests). Resets counters and — if a sink is bound — emits `session.started`.
+  Future<void> startSession(String sessionId) async {
+    _prefs ??= await SharedPreferences.getInstance();
+    _beginSession(sessionId);
+  }
+
+  /// Synchronous session begin. Prefs writes are fire-and-forget so the
+  /// `session.started` emit — and a rotation's finalize→start pair — complete
+  /// synchronously (no `await` splitting the bookends across microtasks).
+  void _beginSession(String sessionId) {
+    _currentSessionId = sessionId;
+    final now = _clock();
+    _sessionStartTime = now;
+    _lastActivityAt = now;
+    _resetCounters();
+
+    if (_prefs != null) {
+      final sessionCount = (_prefs!.getInt(_sessionCountKey) ?? 0) + 1;
+      _prefs!.setInt(_sessionCountKey, sessionCount);
+      if (sessionCount == 1) _prefs!.setBool(_firstSessionKey, true);
+    }
+
+    _persist();
+    _emit?.call(EdgeEvent.session('session.started', {
+      'session.id': sessionId,
+      'session.start_time': now.toIso8601String(),
+    }));
+  }
+
+  /// The "next event" idle check. Called by the Collector before every event:
+  /// rotate if idle exceeded (backdated to the last activity), else just bump
+  /// `lastActivityAt`. No-op while rotating (the bookends re-enter here).
+  void beforeEvent() {
+    if (_rotating || _currentSessionId == null || _lastActivityAt == null) {
+      return;
+    }
+    final now = _clock();
+    if (now.difference(_lastActivityAt!) > idleTimeout) {
+      _rotate(_lastActivityAt!);
+    } else {
+      _lastActivityAt = now;
     }
   }
 
-  /// Get comprehensive session attributes
-  Map<String, String> getSessionAttributes() {
-    if (_currentSessionId == null || _sessionStartTime == null) {
-      return {};
+  /// `AppLifecycleState.paused`: mark the background time and persist. The
+  /// caller flushes the Pipeline first (nothing lost to a subsequent kill).
+  /// **Never finalizes** — a brief app-switch must not rotate the session.
+  void handlePause() {
+    if (_currentSessionId == null) return;
+    _lastActivityAt = _clock();
+    _persist();
+  }
+
+  /// `AppLifecycleState.resumed`: rotate if we were idle past the window
+  /// (backdated to the background time), else continue the same session.
+  void handleResume() {
+    if (_currentSessionId == null || _lastActivityAt == null) return;
+    final now = _clock();
+    if (now.difference(_lastActivityAt!) > idleTimeout) {
+      _rotate(_lastActivityAt!);
+    } else {
+      _lastActivityAt = now;
+      _persist();
     }
+  }
 
-    final now = DateTime.now();
-    final duration = now.difference(_sessionStartTime!);
+  void _rotate(DateTime backdatedEnd) {
+    if (_rotating) return;
+    _rotating = true;
+    _emitFinalizeCurrent(backdatedEnd);
+    _beginSession(_newId());
+    _rotating = false;
+  }
 
+  // ==================== COUNTERS ====================
+
+  void recordEvent() => _eventCount++;
+  void recordMetric() => _metricCount++;
+  void recordError() => _errorCount++;
+  void recordCrash() => _crashCount++;
+  void recordHttpRequest() => _httpRequestCount++;
+
+  void _resetCounters() {
+    _eventCount = 0;
+    _metricCount = 0;
+    _errorCount = 0;
+    _crashCount = 0;
+    _httpRequestCount = 0;
+    _visitedScreens.clear();
+    _screenJourney.clear();
+  }
+
+  /// Ordered route path (for `screen_journey`) + distinct set (for count).
+  void recordScreen(String screenName) {
+    _visitedScreens.add(screenName);
+    _screenJourney.add(screenName);
+  }
+
+  // ==================== FINALIZE / JOURNEY SUMMARY ====================
+
+  void _emitFinalizeCurrent(DateTime end) {
+    if (_currentSessionId == null || _sessionStartTime == null) return;
+    _emit?.call(EdgeEvent.session(
+        'session.finalized',
+        _journeyAttributes(
+          id: _currentSessionId!,
+          start: _sessionStartTime!,
+          end: end,
+          eventCount: _eventCount,
+          errorCount: _errorCount,
+          crashCount: _crashCount,
+          httpCount: _httpRequestCount,
+          screenCount: _visitedScreens.length,
+          journey: _screenJourney,
+        )));
+  }
+
+  void _emitFinalizeFromRecord(String raw) {
+    final Map<String, dynamic> r;
+    try {
+      r = jsonDecode(raw) as Map<String, dynamic>;
+    } catch (_) {
+      return; // corrupt record → skip recovery rather than crash init
+    }
+    final start = DateTime.tryParse(r['start'] as String? ?? '');
+    final end = DateTime.tryParse(r['lastActivity'] as String? ?? '');
+    final id = r['id'] as String?;
+    if (id == null || start == null || end == null) return;
+    _emit?.call(EdgeEvent.session(
+        'session.finalized',
+        _journeyAttributes(
+          id: id,
+          start: start,
+          end: end,
+          eventCount: (r['eventCount'] as num?)?.toInt() ?? 0,
+          errorCount: (r['errorCount'] as num?)?.toInt() ?? 0,
+          crashCount: (r['crashCount'] as num?)?.toInt() ?? 0,
+          httpCount: (r['httpCount'] as num?)?.toInt() ?? 0,
+          screenCount: (r['screenCount'] as num?)?.toInt() ?? 0,
+          journey: (r['journey'] as List?)?.cast<String>() ?? const [],
+          recovered: true,
+        )));
+  }
+
+  Map<String, String> _journeyAttributes({
+    required String id,
+    required DateTime start,
+    required DateTime end,
+    required int eventCount,
+    required int errorCount,
+    required int crashCount,
+    required int httpCount,
+    required int screenCount,
+    required List<String> journey,
+    bool recovered = false,
+  }) {
+    // Last 20 hops only, so a multi-hour session can't emit a giant attribute.
+    final capped =
+        journey.length > 20 ? journey.sublist(journey.length - 20) : journey;
+    return {
+      'session.id': id,
+      'session.start_time': start.toIso8601String(),
+      'session.end_time': end.toIso8601String(),
+      'session.duration_ms': end.difference(start).inMilliseconds.toString(),
+      'session.event_count': eventCount.toString(),
+      'session.error_count': errorCount.toString(),
+      'session.crash_count': crashCount.toString(),
+      'session.screen_count': screenCount.toString(),
+      'session.http_request_count': httpCount.toString(),
+      'session.screen_journey': capped.join('>'),
+      if (recovered) 'session.recovered': 'true',
+    };
+  }
+
+  // ponytail: persist on start/pause/resume only, not per-event — one prefs
+  // write per lifecycle edge, not per event. Ceiling: a kill with no preceding
+  // `paused` loses activity since the last edge. Accepted because iOS/Android
+  // both deliver `paused` before a kill (spec §2.2); persist per-event if that
+  // assumption ever fails.
+  void _persist() {
+    if (_prefs == null || _currentSessionId == null) return;
+    _prefs!.setString(
+      _recordKey,
+      jsonEncode({
+        'id': _currentSessionId,
+        'start': _sessionStartTime!.toIso8601String(),
+        'lastActivity': _lastActivityAt!.toIso8601String(),
+        'eventCount': _eventCount,
+        'errorCount': _errorCount,
+        'crashCount': _crashCount,
+        'httpCount': _httpRequestCount,
+        'screenCount': _visitedScreens.length,
+        'journey': _screenJourney,
+      }),
+    );
+  }
+
+  // ==================== CONTEXT ATTRIBUTES ====================
+
+  /// Live session attributes merged into every event by `ContextManager`.
+  Map<String, String> getSessionAttributes() {
+    if (_currentSessionId == null || _sessionStartTime == null) return {};
+    final duration = _clock().difference(_sessionStartTime!);
     return {
       'session.id': _currentSessionId!,
       'session.start_time': _sessionStartTime!.toIso8601String(),
       'session.duration_ms': duration.inMilliseconds.toString(),
       'session.event_count': _eventCount.toString(),
       'session.metric_count': _metricCount.toString(),
+      'session.error_count': _errorCount.toString(),
+      'session.crash_count': _crashCount.toString(),
+      'session.http_request_count': _httpRequestCount.toString(),
       'session.screen_count': _visitedScreens.length.toString(),
       'session.visited_screens': _visitedScreens.join(','),
       'session.is_first_session': _isFirstSession().toString(),
@@ -57,71 +303,38 @@ class SessionManager {
     };
   }
 
-  /// Record an event (increment counter)
-  void recordEvent() {
-    _eventCount++;
-  }
-
-  /// Record a metric (increment counter)
-  void recordMetric() {
-    _metricCount++;
-  }
-
-  /// Record a visited screen
-  void recordScreen(String screenName) {
-    _visitedScreens.add(screenName);
-  }
-
-  /// Get current session ID
   String? get currentSessionId => _currentSessionId;
-
-  /// Get session start time
   DateTime? get sessionStartTime => _sessionStartTime;
+  Duration? get sessionDuration => _sessionStartTime == null
+      ? null
+      : _clock().difference(_sessionStartTime!);
 
-  /// Get session duration
-  Duration? get sessionDuration {
-    if (_sessionStartTime == null) return null;
-    return DateTime.now().difference(_sessionStartTime!);
-  }
+  bool _isFirstSession() => _prefs?.getBool(_firstSessionKey) ?? false;
+  int _getTotalSessions() => _prefs?.getInt(_sessionCountKey) ?? 0;
 
-  /// Check if this is the first session ever
-  bool _isFirstSession() {
-    if (_prefs == null) return false;
-    return _prefs!.getBool(_firstSessionKey) ?? false;
-  }
+  Map<String, dynamic> getSessionStats() => {
+        'sessionId': _currentSessionId,
+        'startTime': _sessionStartTime?.toIso8601String(),
+        'duration': sessionDuration?.inMilliseconds,
+        'eventCount': _eventCount,
+        'metricCount': _metricCount,
+        'errorCount': _errorCount,
+        'crashCount': _crashCount,
+        'httpRequestCount': _httpRequestCount,
+        'screenCount': _visitedScreens.length,
+        'visitedScreens': _visitedScreens.toList(),
+        'screenJourney': List<String>.from(_screenJourney),
+        'isFirstSession': _isFirstSession(),
+        'totalSessions': _getTotalSessions(),
+      };
 
-  /// Get total number of sessions
-  int _getTotalSessions() {
-    if (_prefs == null) return 0;
-    return _prefs!.getInt(_sessionCountKey) ?? 0;
-  }
-
-  /// Get session statistics
-  Map<String, dynamic> getSessionStats() {
-    return {
-      'sessionId': _currentSessionId,
-      'startTime': _sessionStartTime?.toIso8601String(),
-      'duration': sessionDuration?.inMilliseconds,
-      'eventCount': _eventCount,
-      'metricCount': _metricCount,
-      'screenCount': _visitedScreens.length,
-      'visitedScreens': _visitedScreens.toList(),
-      'isFirstSession': _isFirstSession(),
-      'totalSessions': _getTotalSessions(),
-    };
-  }
-
-  /// End the current session
+  /// Clear in-memory state (call on dispose). Deliberately leaves the persisted
+  /// record intact so the next launch backdate-finalizes this session.
   void endSession() {
-    // Clear first session flag after first session ends
-    if (_isFirstSession()) {
-      _prefs?.setBool(_firstSessionKey, false);
-    }
-
+    if (_isFirstSession()) _prefs?.setBool(_firstSessionKey, false);
     _currentSessionId = null;
     _sessionStartTime = null;
-    _eventCount = 0;
-    _metricCount = 0;
-    _visitedScreens.clear();
+    _lastActivityAt = null;
+    _resetCounters();
   }
 }

--- a/edge_telemetry_flutter/test/unit/managers/session_manager_test.dart
+++ b/edge_telemetry_flutter/test/unit/managers/session_manager_test.dart
@@ -1,0 +1,186 @@
+// Tests for the timer-free lazy session model (ticket #24): idle rotation,
+// pause/finalize, kill-recovery, and the journey summary on session.finalized.
+
+import 'package:edge_telemetry_flutter/src/core/edge_event.dart';
+import 'package:edge_telemetry_flutter/src/managers/session_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const idle = Duration(minutes: 30);
+
+  late List<EdgeEvent> emitted;
+  late DateTime clock;
+  late int idCounter;
+
+  SessionManager build() => SessionManager(
+        emit: emitted.add,
+        newSessionId: () => 'session_${++idCounter}',
+        clock: () => clock,
+        idleTimeout: idle,
+      );
+
+  Map<String, String> attrsOf(EdgeEvent e) => e.attributes;
+  Iterable<EdgeEvent> named(String name) =>
+      emitted.where((e) => e.name == name);
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    emitted = [];
+    clock = DateTime(2026, 1, 1, 9, 0, 0);
+    idCounter = 0;
+  });
+
+  group('start', () {
+    test('recoverAndStart emits one immediate session.started', () async {
+      await build().recoverAndStart();
+
+      final started = named('session.started').toList();
+      expect(started, hasLength(1));
+      expect(started.single.priority, EventPriority.immediate);
+      expect(attrsOf(started.single)['session.id'], 'session_1');
+      expect(named('session.finalized'), isEmpty); // nothing to recover
+    });
+  });
+
+  group('lazy idle rotation (no timer)', () {
+    test('beforeEvent past the window finalizes (backdated) + starts fresh',
+        () async {
+      final sm = build();
+      await sm.recoverAndStart(); // session_1 @ 09:00
+
+      clock = clock.add(const Duration(minutes: 5));
+      sm.beforeEvent(); // activity @ 09:05, no rotation
+      expect(named('session.finalized'), isEmpty);
+
+      clock = clock.add(const Duration(minutes: 35)); // 09:40, 35min idle
+      sm.beforeEvent();
+
+      final fin = named('session.finalized').single;
+      expect(attrsOf(fin)['session.id'], 'session_1');
+      // Backdated end == last activity (09:05), not now (09:40).
+      expect(attrsOf(fin)['session.end_time'],
+          DateTime(2026, 1, 1, 9, 5).toIso8601String());
+      expect(attrsOf(fin)['session.duration_ms'],
+          const Duration(minutes: 5).inMilliseconds.toString());
+
+      expect(named('session.started').map((e) => attrsOf(e)['session.id']),
+          ['session_1', 'session_2']);
+    });
+
+    test('beforeEvent within the window does not rotate', () async {
+      final sm = build();
+      await sm.recoverAndStart();
+
+      clock = clock.add(const Duration(minutes: 29));
+      sm.beforeEvent();
+
+      expect(named('session.finalized'), isEmpty);
+      expect(sm.currentSessionId, 'session_1');
+    });
+  });
+
+  group('pause / resume', () {
+    test('pause marks without finalizing; resume within window continues',
+        () async {
+      final sm = build();
+      await sm.recoverAndStart();
+
+      clock = clock.add(const Duration(minutes: 10));
+      sm.handlePause();
+      expect(named('session.finalized'), isEmpty);
+
+      clock = clock.add(const Duration(minutes: 10)); // 20min backgrounded
+      sm.handleResume();
+
+      expect(named('session.finalized'), isEmpty);
+      expect(sm.currentSessionId, 'session_1');
+    });
+
+    test('resume after idle finalizes backdated to background time', () async {
+      final sm = build();
+      await sm.recoverAndStart();
+
+      clock = clock.add(const Duration(minutes: 2));
+      sm.handlePause(); // background @ 09:02
+
+      clock = clock.add(const Duration(minutes: 45)); // 45min later
+      sm.handleResume();
+
+      final fin = named('session.finalized').single;
+      expect(attrsOf(fin)['session.id'], 'session_1');
+      expect(attrsOf(fin)['session.end_time'],
+          DateTime(2026, 1, 1, 9, 2).toIso8601String());
+      expect(sm.currentSessionId, 'session_2');
+    });
+  });
+
+  group('kill-recovery', () {
+    test('a persisted killed session is finalized backdated on next launch',
+        () async {
+      // Launch 1: run, record activity, background (persists the record), then
+      // the process is killed (no clean finalize).
+      final sm1 = build();
+      await sm1.recoverAndStart();
+      sm1.recordScreen('/home');
+      sm1.recordHttpRequest();
+      clock = clock.add(const Duration(minutes: 3));
+      sm1.handlePause(); // persists lastActivity @ 09:03
+
+      // Launch 2: fresh manager, later clock. Recovery finalizes session_1.
+      emitted = [];
+      idCounter = 100;
+      clock = DateTime(2026, 1, 1, 12, 0, 0);
+      final sm2 = build();
+      await sm2.recoverAndStart();
+
+      final fin = named('session.finalized').single;
+      expect(attrsOf(fin)['session.id'], 'session_1');
+      expect(attrsOf(fin)['session.recovered'], 'true');
+      expect(attrsOf(fin)['session.end_time'],
+          DateTime(2026, 1, 1, 9, 3).toIso8601String());
+      expect(attrsOf(fin)['session.http_request_count'], '1');
+      expect(attrsOf(fin)['session.screen_count'], '1');
+      expect(attrsOf(fin)['session.screen_journey'], '/home');
+
+      // A brand-new session is live afterwards.
+      expect(sm2.currentSessionId, 'session_101');
+    });
+  });
+
+  group('journey summary', () {
+    test('counts and 20-hop-capped screen_journey', () async {
+      final sm = build();
+      await sm.recoverAndStart();
+
+      sm.recordEvent();
+      sm.recordEvent();
+      sm.recordCrash();
+      sm.recordError();
+      sm.recordHttpRequest();
+      sm.recordHttpRequest();
+      sm.recordHttpRequest();
+      for (var i = 0; i < 25; i++) {
+        sm.recordScreen('/s$i');
+      }
+
+      clock = clock.add(const Duration(minutes: 31));
+      sm.beforeEvent(); // rotate → finalize session_1
+
+      final fin = named('session.finalized').single;
+      final a = attrsOf(fin);
+      expect(a['session.event_count'], '2');
+      expect(a['session.crash_count'], '1');
+      expect(a['session.error_count'], '1');
+      expect(a['session.http_request_count'], '3');
+      expect(a['session.screen_count'], '25');
+
+      final journey = a['session.screen_journey']!.split('>');
+      expect(journey, hasLength(20)); // last 20 hops only
+      expect(journey.first, '/s5');
+      expect(journey.last, '/s24');
+    });
+  });
+}


### PR DESCRIPTION
Closes #24 (spec #15, Phase 3).

## What
Timer-free lazy session model. Sessions rotate on a **30-minute idle check** evaluated lazily on the next event (`Collector.beforeEvent`) or on resume — **no `Timer.periodic`**, since a backgrounded Flutter app can't run timers. `paused` flushes and marks (never finalizes); the finalize is deferred to resume-after-idle, the next in-app rotation, or the next launch — always **backdated** to the last activity.

## Changes
- **`SessionManager`** — idle rotation, pause/resume, `recoverAndStart` (kill-recovery via a `shared_preferences` session record), journey counters, 20-hop-capped `screen_journey`. Injectable clock/id/sink for testability.
- **`EdgeEvent.session()`** — immediate+bypass bookend factory for `session.started` / `session.finalized`.
- **`Collector`** — per-event idle check + crash/error/http journey counters by canon name.
- **`LifecycleCaptureHook`** (new) — `paused`=flush+mark, `resume`=rotate-if-idle, emits canon `app_lifecycle`.
- **Facade/wiring** — session starts after the graph is built; bookend sink late-bound to the Collector.

## Acceptance criteria
- [x] Lazy 30-min idle rotation, no `Timer.periodic`
- [x] `paused`=flush+mark; finalize on resume-after-idle or next-launch (backdated)
- [x] `session.id` + last activity persisted for kill-recovery
- [x] `session.finalized` carries full journey summary (`duration_ms`, `event/error/crash/http_request/screen_count`, 20-hop `screen_journey` cap)
- [x] `SessionManager` tests: idle rotation, pause/finalize/kill-recovery, journey summary

## Verification
`flutter analyze` clean · **58/58 tests pass** · `dart format` applied.

## Notes
- Persistence refreshes on lifecycle edges (start/pause/resume), not per-event — a kill with no preceding `paused` loses post-edge activity. Accepted because iOS/Android both deliver `paused` before a kill (spec §2.2).
- `crash_count`/`error_count` overlap for non-fatal Dart errors — this matches the §2.3 table's literal definitions (`crash_count`="app.crash events", `error_count`="non-fatal errors").