### PR TITLE
wayfinder #25: two-axis sampling (priority x sampled)

### DIFF
--- a/edge_telemetry_flutter/CHANGELOG.md
+++ b/edge_telemetry_flutter/CHANGELOG.md
@@ -83,6 +83,16 @@ section below. Final version bump + migration guide land with the rest of v2.0.0
 - **ADDED**: `maxQueueSize` config knob (default 200) — batches drop-oldest
   past the cap; crashes (`crash_` filename prefix) are exempt and never dropped.
 
+### 🎚️ Two-axis sampling (Phase 3)
+- **ADDED**: `sampleRate` (config, default 1.0) is now live — rolled **once per
+  session** and stored as `session.sampled`. A sampled-out session drops its
+  subject-to-sample events coherently (whole session or none). At 1.0 there is
+  no roll and `session.sampled` is omitted (wire unchanged).
+- **ADDED**: send-priority (immediate vs batched) and sampling (bypass vs
+  subject-to-sample) are now orthogonal axes. `app.crash` and the `session.*`
+  bookends are immediate+bypass; `user.profile.update` is **batched-but-bypass**
+  — an identity mutation always lands even in a sampled-out session.
+
 ### 🧹 Internal
 - **REMOVED**: `opentelemetry` dependency, `SpanManager`, `EventTrackerImpl`,
   the `EventTracker` interface, and the `useJsonFormat` dual-backend branches.

--- a/edge_telemetry_flutter/README.md
+++ b/edge_telemetry_flutter/README.md
@@ -121,6 +121,10 @@ await EdgeTelemetry.initialize(
   // 🔧 Advanced Options
   debugMode: true,                   // Enable console logging
   eventBatchSize: 30,               // Events per batch
+  sampleRate: 1.0,                  // Fraction of sessions kept (0.0–1.0). Rolled
+                                     // once/session: a sampled-out session drops its
+                                     // events, but crashes, session bookends, and
+                                     // user.profile.update always land. 1.0 = keep all.
   enableLocalReporting: true,       // Store data locally for reports
 
   // 🏷️ Global attributes added to all telemetry

--- a/edge_telemetry_flutter/lib/src/core/collector.dart
+++ b/edge_telemetry_flutter/lib/src/core/collector.dart
@@ -24,12 +24,15 @@ class Collector implements EventSink {
     required this.pipeline,
   });
 
-  /// Sample gate. Immediate events (crash) always pass; batched events are
-  /// dropped only when the session rolled sampled-out (`session.sampled=false`).
-  // ponytail: default is keep-all (no `session.sampled` set) → byte-identical
-  // with v1.5.2. The per-session roll that sets the flag is session work (#9).
+  /// Sample gate on the sampling axis (orthogonal to send-priority). Bypass
+  /// events — crash, `session.*` bookends, `user.profile.update` — always pass;
+  /// subject-to-sample events are dropped only when the session rolled
+  /// sampled-out (`session.sampled=false`), so a sampled-out session drops its
+  /// whole event stream coherently while still bracketing + reporting crashes.
+  // ponytail: default is keep-all (no `session.sampled` set, sampleRate 1.0) →
+  // byte-identical with v1.5.2. The per-session roll lives in SessionManager.
   bool _shouldSample(EdgeEvent event) {
-    if (event.priority == EventPriority.immediate) return true;
+    if (event.bypassSampling) return true;
     return context.snapshot()['session.sampled'] != 'false';
   }
 

--- a/edge_telemetry_flutter/lib/src/core/config/telemetry_config.dart
+++ b/edge_telemetry_flutter/lib/src/core/config/telemetry_config.dart
@@ -14,8 +14,10 @@ class TelemetryConfig {
   /// Collector 401s without it in api_key mode — dev/self-hosted only).
   final String? apiKey;
 
-  /// Fraction of sessions kept (0.0–1.0). Config key landed for family
-  /// alignment; the per-session sampling roll is wired in #9.
+  /// Fraction of sessions kept (0.0–1.0). Rolled once per session (#25): a
+  /// sampled-out session drops its subject-to-sample events coherently, while
+  /// crashes, `session.*` bookends, and `user.profile.update` still land. 1.0
+  /// (default) = no roll, keep everything.
   final double sampleRate;
 
   /// Enable debug logging and console output

--- a/edge_telemetry_flutter/lib/src/core/edge_event.dart
+++ b/edge_telemetry_flutter/lib/src/core/edge_event.dart
@@ -1,6 +1,7 @@
 // lib/src/core/edge_event.dart
 
-/// Send priority for an [EdgeEvent].
+/// Send priority for an [EdgeEvent] — one of two orthogonal axes (the other is
+/// [EdgeEvent.bypassSampling]).
 ///
 /// - [batched]: buffered by the Pipeline and sent in a `type:"batch"` envelope.
 /// - [immediate]: sent straight away, bypassing the batch (crash rail).
@@ -33,6 +34,14 @@ class EdgeEvent {
 
   final EventPriority priority;
 
+  /// Sampling axis, orthogonal to [priority]. When true the event bypasses the
+  /// per-session sample gate (`session.sampled`) and always reaches the wire.
+  ///
+  /// `app.crash` and the `session.*` bookends are bypass (they ride the immediate
+  /// rail too); `user.profile.update` is **batched-but-bypass** — an identity
+  /// mutation that isn't time-critical but must never be sampled away.
+  final bool bypassSampling;
+
   /// Whether this event bumps the session event/metric counters.
   ///
   /// Matches v1.5.2: only events that flowed through the public facade API
@@ -44,6 +53,7 @@ class EdgeEvent {
     this.name, {
     this.attributes = const {},
     this.countsToSession = false,
+    this.bypassSampling = false,
   })  : type = 'event',
         value = null,
         error = null,
@@ -58,6 +68,7 @@ class EdgeEvent {
   })  : type = 'metric',
         error = null,
         stackTrace = null,
+        bypassSampling = false,
         priority = EventPriority.batched;
 
   /// The single source of truth for the `app.crash` wire shape.
@@ -94,6 +105,7 @@ class EdgeEvent {
         error = null,
         stackTrace = null,
         countsToSession = false,
+        bypassSampling = true,
         priority = EventPriority.immediate;
 
   /// The session bookends (`session.started` / `session.finalized`). Immediate
@@ -107,5 +119,6 @@ class EdgeEvent {
         error = null,
         stackTrace = null,
         countsToSession = false,
+        bypassSampling = true,
         priority = EventPriority.immediate;
 }

--- a/edge_telemetry_flutter/lib/src/facade/edge_telemetry.dart
+++ b/edge_telemetry_flutter/lib/src/facade/edge_telemetry.dart
@@ -167,7 +167,14 @@ class EdgeTelemetry {
       // Timer-free lazy session model. The session is started *after* the
       // wiring is built (below) so `recoverAndStart` can emit session.started
       // (and any backdated kill-recovery finalize) through the Collector.
-      _sessionManager = SessionManager(newSessionId: _generateSessionId);
+      // Per-session sampling roll only when sampling is on (rate < 1.0). At 1.0
+      // there's no roll → no `session.sampled` on the wire (byte-identical).
+      _sessionManager = SessionManager(
+        newSessionId: _generateSessionId,
+        sampledRoll: config.sampleRate >= 1.0
+            ? null
+            : () => Random().nextDouble() < config.sampleRate,
+      );
 
       await _loadProfileVersion();
 
@@ -427,9 +434,11 @@ class EdgeTelemetry {
 
   /// Emit a profile event direct — no session-counter bump, no local store —
   /// matching v1.5.2, which sent these via the tracker (not the public API).
+  /// Batched-but-bypass: an identity mutation isn't time-critical, but must land
+  /// even in a sampled-out session (#25).
   void _emitProfileEvent(String eventName, Map<String, String> attributes) {
     _wiring!.collector.add(EdgeEvent.event(eventName,
-        attributes: attributes, countsToSession: false));
+        attributes: attributes, countsToSession: false, bypassSampling: true));
   }
 
   /// Clear user profile (but keep auto-generated user ID).

--- a/edge_telemetry_flutter/lib/src/managers/session_manager.dart
+++ b/edge_telemetry_flutter/lib/src/managers/session_manager.dart
@@ -37,12 +37,21 @@ class SessionManager {
   /// Idle window after which the next activity rotates the session.
   final Duration idleTimeout;
 
+  /// Per-session sampling roll (spec #15 Phase 3 / ticket #25). Called once at
+  /// [_beginSession]; true = keep this session's subject-to-sample events.
+  /// Null = keep-all (default, `sampleRate` 1.0) → no `session.sampled` emitted,
+  /// byte-identical with the pre-sampling wire.
+  final bool Function()? _sampledRoll;
+
   SharedPreferences? _prefs;
 
   String? _currentSessionId;
   DateTime? _sessionStartTime;
   DateTime? _lastActivityAt;
   bool _rotating = false;
+
+  /// This session's roll outcome as a wire string, or null when keep-all.
+  String? _sampled;
 
   // Journey counters.
   int _eventCount = 0;
@@ -57,12 +66,14 @@ class SessionManager {
     void Function(EdgeEvent event)? emit,
     String Function()? newSessionId,
     DateTime Function()? clock,
+    bool Function()? sampledRoll,
     this.idleTimeout = const Duration(minutes: 30),
     SharedPreferences? prefs,
   })  : _emit = emit,
         _newId = newSessionId ??
             (() => 'session_${DateTime.now().millisecondsSinceEpoch}'),
         _clock = clock ?? DateTime.now,
+        _sampledRoll = sampledRoll,
         _prefs = prefs;
 
   /// Late-bind the sink once the Collector exists (breaks the session↔collector
@@ -98,6 +109,8 @@ class SessionManager {
     final now = _clock();
     _sessionStartTime = now;
     _lastActivityAt = now;
+    // Roll sampling once per session; the whole session drops-or-keeps coherently.
+    _sampled = _sampledRoll == null ? null : _sampledRoll!().toString();
     _resetCounters();
 
     if (_prefs != null) {
@@ -300,6 +313,7 @@ class SessionManager {
       'session.visited_screens': _visitedScreens.join(','),
       'session.is_first_session': _isFirstSession().toString(),
       'session.total_sessions': _getTotalSessions().toString(),
+      if (_sampled != null) 'session.sampled': _sampled!,
     };
   }
 

--- a/edge_telemetry_flutter/test/unit/architecture/seams_test.dart
+++ b/edge_telemetry_flutter/test/unit/architecture/seams_test.dart
@@ -220,13 +220,37 @@ void main() {
       // A canon event (passes the allowlist) so the drop is purely sampling.
       collector.add(const EdgeEvent.event('navigation'));
       await Future<void>(() {});
-      expect(sender.sent, isEmpty); // batched event dropped
+      expect(sender.sent, isEmpty); // subject-to-sample event dropped
+
+      // Batched-but-bypass: identity mutation lands (in a batch) when sampled out.
+      collector.add(
+          const EdgeEvent.event('user.profile.update', bypassSampling: true));
+      await Future<void>(() {});
+      expect(sender.sent, hasLength(1));
+      expect(sender.sent.single['type'], 'telemetry_batch');
+      expect((sender.sent.single['events'] as List).single['eventName'],
+          'user.profile.update');
 
       collector.add(EdgeEvent.error(StateError('boom')));
       await Future<void>(() {});
-      expect(sender.sent, hasLength(1)); // crash still sent
-      expect(sender.sent.single['type'], 'event'); // immediate app.crash
-      expect(sender.sent.single['eventName'], 'app.crash');
+      expect(sender.sent, hasLength(2)); // crash still sent (immediate+bypass)
+      expect(sender.sent[1]['type'], 'event'); // immediate app.crash
+      expect(sender.sent[1]['eventName'], 'app.crash');
+    });
+
+    test('sampleRate rolled once/session → stored as session.sampled',
+        () async {
+      SharedPreferences.setMockInitialValues({});
+      // Deterministic roll: sampled-out.
+      final session = SessionManager(sampledRoll: () => false);
+      await session.startSession('session_r');
+      expect(session.getSessionAttributes()['session.sampled'], 'false');
+
+      // Default (no roll, sampleRate 1.0) omits the flag entirely → keep-all.
+      final keepAll = SessionManager();
+      await keepAll.startSession('session_k');
+      expect(keepAll.getSessionAttributes().containsKey('session.sampled'),
+          isFalse);
     });
   });
 


### PR DESCRIPTION
Closes #25.

## What
Split **send-priority** (immediate vs batched) and **sampling** (bypass vs subject-to-sample) into two orthogonal axes on `EdgeEvent`.

- `sampleRate` is now live: rolled **once per session** in `SessionManager`, stored as `session.sampled`. A sampled-out session drops its subject-to-sample events coherently (whole session or none). Rate `1.0` (default) = no roll, `session.sampled` omitted, wire byte-identical.
- `Collector._shouldSample` gates on the new `bypassSampling` axis instead of `priority`: `app.crash` + `session.*` bookends stay immediate+bypass; `user.profile.update` is **batched-but-bypass** (identity mutation always lands, even when sampled out).

## Acceptance criteria
- [x] `sampleRate` rolled once/session, stored as `session.sampled`
- [x] Sampled-out → subject-to-sample events dropped; crash + session bookends still sent
- [x] `user.profile.update` = batched-but-bypass
- [x] `Collector._shouldSample` seam test: force sampled-out, assert drops vs bypass

## Tests
Seam 5 extended (drop vs bypass + roll storage/omission). Full suite 59/59 green, `flutter analyze` clean.

Blocked by #24 (merged).