### PR TITLE
wayfinder #26: breadcrumb ring + Flutter capture-more diagnostics

### DIFF
--- a/edge_telemetry_flutter/CHANGELOG.md
+++ b/edge_telemetry_flutter/CHANGELOG.md
@@ -93,6 +93,26 @@ section below. Final version bump + migration guide land with the rest of v2.0.0
   bookends are immediate+bypass; `user.profile.update` is **batched-but-bypass**
   — an identity mutation always lands even in a sampled-out session.
 
+### 🍞 Breadcrumbs & Flutter diagnostics (Phase 3)
+- **CHANGED**: the breadcrumb ring is now **20 entries**, crash-scoped. It is
+  attached to every `app.crash` as `crash.breadcrumbs` (JSON-encoded) and never
+  appears in the global snapshot. Auto-crumbs now come from navigation, HTTP
+  (sanitized **path only** — no query string), and lifecycle transitions;
+  `addBreadcrumb(message, {category, level, data})` adds manual ones.
+- **ADDED**: `frame_render_time` now carries `build_time_ms` (UI-thread build)
+  and `raster_time_ms` (GPU raster) — the UI-vs-GPU jank split.
+- **ADDED**: `navigation` and `screen.duration` carry `route.type` and
+  `route.has_arguments` (**boolean only** — argument values are never captured).
+- **CHANGED**: `page_load` now carries `startup.type` (`cold`/`warm`) and
+  `startup.time_to_first_frame_ms`. The latter is **SDK-init-relative** — it
+  undercounts everything before `initialize()`, so call it as early as possible
+  in `main()`.
+- **ADDED**: `app_lifecycle` carries `lifecycle.state` (raw `AppLifecycleState`).
+- **ADDED**: every event carries `device.platform_brightness` (`light`/`dark`).
+  `device.text_scale_factor` / `device.reduce_motion` are **opt-in** behind the
+  new `initialize(captureAccessibilityContext:)` flag (default `false`, pending
+  privacy sign-off — they are accessibility-sensitive).
+
 ### 🧹 Internal
 - **REMOVED**: `opentelemetry` dependency, `SpanManager`, `EventTrackerImpl`,
   the `EventTracker` interface, and the `useJsonFormat` dual-backend branches.

--- a/edge_telemetry_flutter/README.md
+++ b/edge_telemetry_flutter/README.md
@@ -59,6 +59,10 @@ class MyApp extends StatelessWidget {
 }
 ```
 
+> ⏱️ **Call `initialize()` as early as possible in `main()`.** `page_load`'s
+> `startup.time_to_first_frame_ms` is measured from SDK init, not process start,
+> so anything before this call is not counted.
+
 **That's it! 🎉** Your app now has comprehensive telemetry:
 - ✅ All HTTP requests automatically tracked
 - ✅ All crashes and errors automatically reported
@@ -126,6 +130,10 @@ await EdgeTelemetry.initialize(
                                      // events, but crashes, session bookends, and
                                      // user.profile.update always land. 1.0 = keep all.
   enableLocalReporting: true,       // Store data locally for reports
+  captureAccessibilityContext: false, // Opt-in: adds device.text_scale_factor +
+                                      // device.reduce_motion (accessibility-
+                                      // sensitive). device.platform_brightness is
+                                      // captured regardless.
 
   // 🏷️ Global attributes added to all telemetry
   globalAttributes: {

--- a/edge_telemetry_flutter/lib/src/capture/http_capture_hook.dart
+++ b/edge_telemetry_flutter/lib/src/capture/http_capture_hook.dart
@@ -1,6 +1,8 @@
 // lib/src/capture/http_capture_hook.dart
 
 import '../core/edge_event.dart';
+import '../core/models/breadcrumb.dart';
+import '../managers/breadcrumb_manager.dart';
 import 'capture_hook.dart';
 import 'http_overrides.dart';
 
@@ -12,9 +14,14 @@ import 'http_overrides.dart';
 /// hot-restarts.
 class HttpCaptureHook implements CaptureHook {
   final bool debugMode;
+
+  /// Crash-context ring: each completed request drops a sanitized-path
+  /// breadcrumb (path only — never the query string, which can carry PII).
+  final BreadcrumbManager? breadcrumbs;
+
   bool _installed = false;
 
-  HttpCaptureHook({this.debugMode = false});
+  HttpCaptureHook({this.debugMode = false, this.breadcrumbs});
 
   @override
   DisposeHandle start(EventSink sink) {
@@ -40,5 +47,17 @@ class HttpCaptureHook implements CaptureHook {
   void _emit(EventSink sink, HttpRequestTelemetry t) {
     sink.add(EdgeEvent.event('http.request',
         attributes: t.toAttributes(), countsToSession: true));
+
+    // Sanitized path only — drop query/fragment so no PII rides the ring.
+    final path = Uri.tryParse(t.url)?.path ?? t.url;
+    breadcrumbs?.addNetworkEvent(
+      '${t.method} $path',
+      level: t.isSuccess ? BreadcrumbLevel.info : BreadcrumbLevel.error,
+      data: {
+        'path': path,
+        'method': t.method,
+        'status': t.statusCode.toString(),
+      },
+    );
   }
 }

--- a/edge_telemetry_flutter/lib/src/capture/lifecycle_capture_hook.dart
+++ b/edge_telemetry_flutter/lib/src/capture/lifecycle_capture_hook.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/widgets.dart';
 
 import '../core/edge_event.dart';
+import '../managers/breadcrumb_manager.dart';
 import '../managers/session_manager.dart';
 import 'capture_hook.dart';
 
@@ -20,9 +21,13 @@ class LifecycleCaptureHook with WidgetsBindingObserver implements CaptureHook {
   /// Flushes the Pipeline buffer (wired to `pipeline.flush`).
   final void Function() flush;
 
+  /// Crash-context ring: each lifecycle transition drops a breadcrumb.
+  final BreadcrumbManager? breadcrumbs;
+
   EventSink? _sink;
 
-  LifecycleCaptureHook({required this.session, required this.flush});
+  LifecycleCaptureHook(
+      {required this.session, required this.flush, this.breadcrumbs});
 
   @override
   DisposeHandle start(EventSink sink) {
@@ -45,8 +50,11 @@ class LifecycleCaptureHook with WidgetsBindingObserver implements CaptureHook {
     }
   }
 
-  void _emit(AppLifecycleState state) =>
-      _sink?.add(EdgeEvent.event('app_lifecycle', attributes: {
-        'lifecycle.state': state.name,
-      }));
+  void _emit(AppLifecycleState state) {
+    breadcrumbs?.addSystemEvent('lifecycle: ${state.name}',
+        data: {'lifecycle.state': state.name});
+    _sink?.add(EdgeEvent.event('app_lifecycle', attributes: {
+      'lifecycle.state': state.name,
+    }));
+  }
 }

--- a/edge_telemetry_flutter/lib/src/capture/perf_capture_hook.dart
+++ b/edge_telemetry_flutter/lib/src/capture/perf_capture_hook.dart
@@ -60,8 +60,13 @@ class PerfCaptureHook implements CaptureHook {
     final startupType = _determineStartupType(startupMs);
 
     sink.add(EdgeEvent.event('page_load', attributes: {
-      'startup.duration_ms': startupMs.toString(),
       'startup.type': startupType,
+      // SDK-init-relative (undercounts anything before initialize()); documented
+      // caveat in README. Measured from hook start → first post-frame callback.
+      'startup.time_to_first_frame_ms': startupMs.toString(),
+      // Kept for backward-compat (== time_to_first_frame_ms); the split is
+      // purely additive — no existing key dropped.
+      'startup.duration_ms': startupMs.toString(),
       'startup.timestamp': DateTime.now().toIso8601String(),
       'startup.first_frame': 'true',
     }));
@@ -80,8 +85,10 @@ class PerfCaptureHook implements CaptureHook {
     final isDropped = totalDuration > 16.67;
 
     sink.add(EdgeEvent.metric('frame_render_time', totalDuration, attributes: {
-      'frame.build_duration_ms': buildDuration.toString(),
-      'frame.raster_duration_ms': rasterDuration.toString(),
+      // Canon split (glossary §1, dotless metric internals): UI-thread build vs
+      // GPU raster — the whole jank-triage decision the single total can't make.
+      'build_time_ms': buildDuration.toString(),
+      'raster_time_ms': rasterDuration.toString(),
       'frame.type': frameType,
       'frame.dropped': isDropped.toString(),
       'metric.unit': 'milliseconds',
@@ -130,11 +137,13 @@ class PerfCaptureHook implements CaptureHook {
     }));
   }
 
-  String _determineStartupType(int durationMs) {
-    if (durationMs < 1000) return 'hot_start';
-    if (durationMs < 3000) return 'warm_start';
-    return 'cold_start';
-  }
+  // Canon startup taxonomy is cold | warm (glossary §4). This hook only runs at
+  // SDK init, so it can't truly see a warm (already-resident) start; a duration
+  // threshold is the passive Dart-side proxy.
+  // ponytail: threshold heuristic; true cold/warm needs the native engine-init
+  // timeline (deferred to the native-crash ticket #10).
+  String _determineStartupType(int durationMs) =>
+      durationMs < 2000 ? 'warm' : 'cold';
 
   String _determineFrameType(double durationMs) {
     if (durationMs <= 16.67) return 'smooth';

--- a/edge_telemetry_flutter/lib/src/core/collector.dart
+++ b/edge_telemetry_flutter/lib/src/core/collector.dart
@@ -1,6 +1,9 @@
 // lib/src/core/collector.dart
 
+import 'dart:convert';
+
 import '../capture/capture_hook.dart';
+import '../managers/breadcrumb_manager.dart';
 import '../managers/context_manager.dart';
 import '../managers/session_manager.dart';
 import 'edge_event.dart';
@@ -18,10 +21,16 @@ class Collector implements EventSink {
   final SessionManager session;
   final Pipeline pipeline;
 
+  /// Crash-scoped breadcrumb ring. When present, its entries are attached to
+  /// every `app.crash` as `crash.breadcrumbs` (spec #15 §5.5) — never in the
+  /// global snapshot. Optional so faked collectors can skip it.
+  final BreadcrumbManager? breadcrumbs;
+
   Collector({
     required this.context,
     required this.session,
     required this.pipeline,
+    this.breadcrumbs,
   });
 
   /// Sample gate on the sampling axis (orthogonal to send-priority). Bypass
@@ -77,6 +86,14 @@ class Collector implements EventSink {
       ...context.snapshot(),
       ...event.attributes,
     }..removeWhere((k, _) => kForbiddenAttributes.contains(k));
+
+    // Crash-scoped breadcrumb attach (spec #15 §5.5): the ring rides only on
+    // `app.crash`, JSON-encoded (attributes are String-valued on the wire).
+    if (event.name == 'app.crash' && breadcrumbs != null) {
+      final crumbs = breadcrumbs!.getBreadcrumbsAsJson();
+      if (crumbs.isNotEmpty) enriched['crash.breadcrumbs'] = jsonEncode(crumbs);
+    }
+
     final timestamp = DateTime.now().toIso8601String();
 
     final wireItem = event.type == 'metric'

--- a/edge_telemetry_flutter/lib/src/core/config/telemetry_config.dart
+++ b/edge_telemetry_flutter/lib/src/core/config/telemetry_config.dart
@@ -76,6 +76,11 @@ class TelemetryConfig {
   /// Use JSON format instead of OpenTelemetry (simpler for most use cases)
   final bool useJsonFormat;
 
+  /// Capture the accessibility-sensitive device keys (`device.text_scale_factor`,
+  /// `device.reduce_motion`). Off by default pending privacy sign-off (glossary
+  /// §6). `device.platform_brightness` is captured regardless — it carries no flag.
+  final bool captureAccessibilityContext;
+
   /// Number of events to batch before sending.
   @Deprecated('Use batchSize. Removed in v3.0.0.')
   final int eventBatchSize;
@@ -103,6 +108,7 @@ class TelemetryConfig {
     this.dataRetentionPeriod = const Duration(days: 30),
     this.useJsonFormat = true,
     this.eventBatchSize = 30,
+    this.captureAccessibilityContext = false,
   });
 
   /// Create a copy of this config with some values overridden
@@ -129,6 +135,7 @@ class TelemetryConfig {
     Duration? dataRetentionPeriod,
     bool? useJsonFormat,
     int? eventBatchSize,
+    bool? captureAccessibilityContext,
   }) {
     return TelemetryConfig(
       serviceName: serviceName ?? this.serviceName,
@@ -159,6 +166,8 @@ class TelemetryConfig {
       useJsonFormat: useJsonFormat ?? this.useJsonFormat,
       // ignore: deprecated_member_use_from_same_package
       eventBatchSize: eventBatchSize ?? this.eventBatchSize,
+      captureAccessibilityContext:
+          captureAccessibilityContext ?? this.captureAccessibilityContext,
     );
   }
 

--- a/edge_telemetry_flutter/lib/src/facade/edge_telemetry.dart
+++ b/edge_telemetry_flutter/lib/src/facade/edge_telemetry.dart
@@ -104,6 +104,7 @@ class EdgeTelemetry {
     bool enableHttpMonitoring = true,
     bool enableCrashReporting = true,
     bool enableLocalReporting = false,
+    bool captureAccessibilityContext = false,
     String? reportStoragePath,
     Duration? dataRetentionPeriod,
     @Deprecated(
@@ -137,6 +138,7 @@ class EdgeTelemetry {
       eventBatchSize: resolvedBatchSize,
       enableHttpMonitoring: enableHttpMonitoring,
       enableCrashReporting: enableCrashReporting,
+      captureAccessibilityContext: captureAccessibilityContext,
     );
 
     await instance._setup(config);
@@ -188,6 +190,7 @@ class EdgeTelemetry {
       final context = ContextManager(
         sessionManager: _sessionManager!,
         global: _globalAttributes,
+        captureAccessibilityContext: config.captureAccessibilityContext,
       );
 
       // Build + start the graph (binds the session bookend sink to the
@@ -518,7 +521,7 @@ class EdgeTelemetry {
 
   void addBreadcrumb(
     String message, {
-    required String category,
+    String category = BreadcrumbCategory.custom,
     BreadcrumbLevel level = BreadcrumbLevel.info,
     Map<String, String>? data,
   }) {

--- a/edge_telemetry_flutter/lib/src/facade/telemetry_wiring.dart
+++ b/edge_telemetry_flutter/lib/src/facade/telemetry_wiring.dart
@@ -90,6 +90,7 @@ class TelemetryWiring {
       context: context,
       session: session,
       pipeline: pipeline,
+      breadcrumbs: breadcrumbs,
     );
 
     // Late-bind the session bookend sink now the Collector exists (breaks the
@@ -111,8 +112,9 @@ class TelemetryWiring {
       disposers.add(PerfCaptureHook().start(collector));
     }
     if (config.enableHttpMonitoring) {
-      disposers
-          .add(HttpCaptureHook(debugMode: config.debugMode).start(collector));
+      disposers.add(
+          HttpCaptureHook(debugMode: config.debugMode, breadcrumbs: breadcrumbs)
+              .start(collector));
     }
     if (config.enableNavigationTracking) {
       navHook = NavCaptureHook(session: session, breadcrumbs: breadcrumbs);
@@ -123,7 +125,8 @@ class TelemetryWiring {
     // plus the canon app_lifecycle event. Always on — it drives the session
     // model, not an optional monitor.
     disposers.add(
-      LifecycleCaptureHook(session: session, flush: pipeline.flush)
+      LifecycleCaptureHook(
+              session: session, flush: pipeline.flush, breadcrumbs: breadcrumbs)
           .start(collector),
     );
 

--- a/edge_telemetry_flutter/lib/src/managers/breadcrumb_manager.dart
+++ b/edge_telemetry_flutter/lib/src/managers/breadcrumb_manager.dart
@@ -6,7 +6,9 @@ import '../core/models/breadcrumb.dart';
 
 /// Manages breadcrumb collection for crash context
 class BreadcrumbManager {
-  static const int _maxBreadcrumbs = 50;
+  // Crash-scoped ring cap (spec #15 §5.5). Small on purpose: the last handful of
+  // steps before a crash is the signal; older ones are noise.
+  static const int _maxBreadcrumbs = 20;
   final Queue<Breadcrumb> _breadcrumbs = Queue<Breadcrumb>();
   final bool _debugMode;
 
@@ -15,7 +17,7 @@ class BreadcrumbManager {
   /// Add a breadcrumb
   void addBreadcrumb(
     String message, {
-    required String category,
+    String category = BreadcrumbCategory.custom,
     BreadcrumbLevel level = BreadcrumbLevel.info,
     Map<String, String>? data,
   }) {

--- a/edge_telemetry_flutter/lib/src/managers/context_manager.dart
+++ b/edge_telemetry_flutter/lib/src/managers/context_manager.dart
@@ -1,5 +1,7 @@
 // lib/src/managers/context_manager.dart
 
+import 'dart:ui';
+
 import 'session_manager.dart';
 
 /// Single source of truth for the mutable global context bag: `device.*`,
@@ -15,10 +17,17 @@ class ContextManager {
   /// Current network type; updated by the network capture hook.
   String networkType;
 
+  /// When true, the accessibility-sensitive device keys
+  /// (`device.text_scale_factor`, `device.reduce_motion`) are captured. Off by
+  /// default — pending privacy sign-off (glossary §6). `device.platform_brightness`
+  /// is benign and always captured, regardless of this flag.
+  final bool captureAccessibilityContext;
+
   ContextManager({
     required this.sessionManager,
     Map<String, String>? global,
     this.networkType = 'unknown',
+    this.captureAccessibilityContext = false,
   }) : _global = {...?global};
 
   /// Set a single global key (e.g. `user.id`, `session.sampled`).
@@ -33,5 +42,24 @@ class ContextManager {
         ..._global,
         ...sessionManager.getSessionAttributes(),
         'network.type': networkType,
+        ..._deviceContext(),
       };
+
+  /// Live rendering/accessibility context read fresh each snapshot (all can
+  /// change at runtime), from the passive `PlatformDispatcher` singleton
+  /// (glossary §6). `platform_brightness` is benign + always on; the two
+  /// accessibility keys are gated behind [captureAccessibilityContext].
+  Map<String, String> _deviceContext() {
+    final dispatcher = PlatformDispatcher.instance;
+    final ctx = <String, String>{
+      'device.platform_brightness':
+          dispatcher.platformBrightness == Brightness.dark ? 'dark' : 'light',
+    };
+    if (captureAccessibilityContext) {
+      ctx['device.text_scale_factor'] = dispatcher.textScaleFactor.toString();
+      ctx['device.reduce_motion'] =
+          dispatcher.accessibilityFeatures.disableAnimations.toString();
+    }
+    return ctx;
+  }
 }

--- a/edge_telemetry_flutter/lib/src/widgets/edge_navigation_observer.dart
+++ b/edge_telemetry_flutter/lib/src/widgets/edge_navigation_observer.dart
@@ -8,7 +8,11 @@ import 'package:flutter/material.dart';
 /// screen tracking and navigation analytics
 class EdgeNavigationObserver extends NavigatorObserver {
   String? _currentRoute;
-  final Map<String, DateTime> _screenStartTimes = {};
+
+  // One record per open screen: its start time + the route context, so
+  // `screen.duration` can carry the same `route.type` / `route.has_arguments`
+  // the `navigation` event did (glossary §3).
+  final Map<String, _ScreenVisit> _screens = {};
 
   final Function(String, {Map<String, String>? attributes})? _onEvent;
 
@@ -57,8 +61,8 @@ class EdgeNavigationObserver extends NavigatorObserver {
       _endScreen(previousRouteName, method);
     }
 
-    // Start timing the new screen
-    _startScreen(routeName);
+    // Start timing the new screen (recording its route context)
+    _startScreen(routeName, route);
 
     // Track navigation event
     _trackNavigationEvent(routeName, previousRouteName, method, route);
@@ -79,22 +83,31 @@ class EdgeNavigationObserver extends NavigatorObserver {
     return 'screen_${routeType}_$routeHash';
   }
 
-  /// Begin timing a screen
-  void _startScreen(String routeName) {
-    _screenStartTimes[routeName] = DateTime.now();
+  /// Begin timing a screen (and record its route context for screen.duration)
+  void _startScreen(String routeName, Route<dynamic> route) {
+    _screens[routeName] = _ScreenVisit(DateTime.now(), _routeContext(route));
   }
+
+  /// The two sanctioned route attrs (glossary §3): the runtime `Route` type and
+  /// a boolean args-present flag — never the argument values (PII). Shared by
+  /// the `navigation` event and `screen.duration`.
+  Map<String, String> _routeContext(Route<dynamic> route) => {
+        'route.type': route.runtimeType.toString(),
+        'route.has_arguments': (route.settings.arguments != null).toString(),
+      };
 
   /// End a screen and track its duration metric
   void _endScreen(String routeName, String exitMethod) {
-    final startTime = _screenStartTimes.remove(routeName);
-    if (startTime == null) return;
+    final visit = _screens.remove(routeName);
+    if (visit == null) return;
 
-    final duration = DateTime.now().difference(startTime);
+    final duration = DateTime.now().difference(visit.start);
     // Canon: screen dwell is the `screen.duration` event (metric→event, §2).
     _onEvent?.call('screen.duration', attributes: {
       'screen.name': routeName,
       'screen.duration_ms': duration.inMilliseconds.toString(),
       'screen.exit_method': exitMethod,
+      ...visit.routeContext,
     });
   }
 
@@ -106,18 +119,12 @@ class EdgeNavigationObserver extends NavigatorObserver {
       'navigation.method': method,
       'navigation.type': 'route_change',
       'navigation.timestamp': DateTime.now().toIso8601String(),
-      'route.type': route.runtimeType.toString(),
+      // route.type + boolean route.has_arguments — never the argument values.
+      ..._routeContext(route),
     };
 
     if (previousRouteName != null) {
       navigationAttributes['navigation.from'] = previousRouteName;
-    }
-
-    // Add route arguments if available
-    if (route.settings.arguments != null) {
-      navigationAttributes['route.has_arguments'] = 'true';
-      navigationAttributes['route.arguments_type'] =
-          route.settings.arguments.runtimeType.toString();
     }
 
     _onEvent?.call('navigation', attributes: navigationAttributes);
@@ -134,6 +141,13 @@ class EdgeNavigationObserver extends NavigatorObserver {
 
   /// Clean up all resources
   void dispose() {
-    _screenStartTimes.clear();
+    _screens.clear();
   }
+}
+
+/// One open screen's timing anchor + its (PII-safe) route context.
+class _ScreenVisit {
+  final DateTime start;
+  final Map<String, String> routeContext;
+  const _ScreenVisit(this.start, this.routeContext);
 }

--- a/edge_telemetry_flutter/test/unit/core/wire_flip_test.dart
+++ b/edge_telemetry_flutter/test/unit/core/wire_flip_test.dart
@@ -63,8 +63,9 @@ Future<(Collector, _RecordingSender)> _wire({
 }
 
 /// Normalize an assembled batch for golden comparison: blank the volatile
-/// timestamps and drop the session.*/network.* attrs (owned by #9, not the
-/// wire-flip canon this fixture pins).
+/// timestamps and drop the session.*/network.* attrs (owned by #9) plus the
+/// live device-context keys (`device.platform_brightness` — owned by #26), none
+/// of which the wire-flip canon (#21) this fixture pins is concerned with.
 Map<String, dynamic> _normalize(Map<String, dynamic> batch) => {
       ...batch,
       'timestamp': '<TS>',
@@ -72,8 +73,12 @@ Map<String, dynamic> _normalize(Map<String, dynamic> batch) => {
         final ev = Map<String, dynamic>.from(e as Map);
         ev['timestamp'] = '<TS>';
         ev['attributes'] = Map<String, dynamic>.from(ev['attributes'] as Map)
-          ..removeWhere(
-              (k, _) => k.startsWith('session.') || k.startsWith('network.'));
+          ..removeWhere((k, _) =>
+              k.startsWith('session.') ||
+              k.startsWith('network.') ||
+              k == 'device.platform_brightness' ||
+              k == 'device.text_scale_factor' ||
+              k == 'device.reduce_motion');
         return ev;
       }).toList(),
     };

--- a/edge_telemetry_flutter/test/unit/diagnostics/capture_more_test.dart
+++ b/edge_telemetry_flutter/test/unit/diagnostics/capture_more_test.dart
@@ -1,0 +1,158 @@
+// test/unit/diagnostics/capture_more_test.dart
+//
+// Wayfinder #26 — the crash-scoped breadcrumb ring + the Flutter-unique
+// "capture more" diagnostics. Asserts behaviour at the seams, not private state.
+
+import 'dart:convert';
+
+import 'package:edge_telemetry_flutter/src/core/collector.dart';
+import 'package:edge_telemetry_flutter/src/core/edge_event.dart';
+import 'package:edge_telemetry_flutter/src/core/offline_queue.dart';
+import 'package:edge_telemetry_flutter/src/core/pipeline.dart';
+import 'package:edge_telemetry_flutter/src/core/retry_transport.dart';
+import 'package:edge_telemetry_flutter/src/managers/breadcrumb_manager.dart';
+import 'package:edge_telemetry_flutter/src/managers/context_manager.dart';
+import 'package:edge_telemetry_flutter/src/managers/session_manager.dart';
+import 'package:edge_telemetry_flutter/src/widgets/edge_navigation_observer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _RecordingSender {
+  final List<Map<String, dynamic>> sent = [];
+  Future<bool> call(Map<String, dynamic> payload) async {
+    sent.add(payload);
+    return true;
+  }
+}
+
+class _NoopQueue extends OfflineQueue {
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<String?> persist(Map<String, dynamic> p,
+          {bool isCrash = false}) async =>
+      null;
+  @override
+  Future<int> drain(Future<bool> Function(Map<String, dynamic>) s) async => 0;
+}
+
+Future<(Collector, _RecordingSender)> _wire(
+    {BreadcrumbManager? breadcrumbs}) async {
+  final sender = _RecordingSender();
+  final session = SessionManager();
+  await session.startSession('session_test');
+  final context =
+      ContextManager(sessionManager: session, global: {'device.id': 'd'});
+  final transport = RetryTransport(
+      endpoint: 'https://x.test', queue: _NoopQueue(), sender: sender.call);
+  final pipeline = Pipeline(transport: transport, batchSize: 1);
+  final collector = Collector(
+      context: context,
+      session: session,
+      pipeline: pipeline,
+      breadcrumbs: breadcrumbs);
+  return (collector, sender);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  group('Breadcrumb ring', () {
+    test('caps at 20 (oldest dropped)', () {
+      final ring = BreadcrumbManager();
+      for (var i = 0; i < 25; i++) {
+        ring.addCustom('crumb_$i');
+      }
+      expect(ring.count, 20);
+      // Most-recent-first; crumb_5..crumb_24 survive, crumb_0..4 dropped.
+      final messages = ring.getBreadcrumbs().map((b) => b.message).toList();
+      expect(messages.first, 'crumb_24');
+      expect(messages.contains('crumb_4'), isFalse);
+    });
+
+    test('attached to app.crash as crash.breadcrumbs, absent on other events',
+        () async {
+      final ring = BreadcrumbManager()..addNavigation('/home');
+      final (collector, sender) = await _wire(breadcrumbs: ring);
+
+      collector.add(EdgeEvent.error(StateError('boom')));
+      await Future<void>(() {});
+
+      // app.crash rides the immediate rail: bare event, not a batch envelope.
+      final crashAttrs = sender.sent.single['attributes'] as Map;
+      expect(crashAttrs.containsKey('crash.breadcrumbs'), isTrue);
+      final decoded =
+          jsonDecode(crashAttrs['crash.breadcrumbs'] as String) as List;
+      expect((decoded.single as Map)['category'], 'navigation');
+
+      // A non-crash event never carries the ring.
+      collector.add(const EdgeEvent.event('navigation'));
+      await Future<void>(() {});
+      final navAttrs =
+          (sender.sent[1]['events'] as List).single['attributes'] as Map;
+      expect(navAttrs.containsKey('crash.breadcrumbs'), isFalse);
+    });
+
+    test('empty ring adds no key', () async {
+      final (collector, sender) = await _wire(breadcrumbs: BreadcrumbManager());
+      collector.add(EdgeEvent.error(StateError('boom')));
+      await Future<void>(() {});
+      final attrs = sender.sent.single['attributes'] as Map;
+      expect(attrs.containsKey('crash.breadcrumbs'), isFalse);
+    });
+  });
+
+  group('Device context', () {
+    test('platform_brightness always present; accessibility keys gated off',
+        () async {
+      final session = SessionManager();
+      await session.startSession('s');
+      final ctx = ContextManager(sessionManager: session);
+      final snap = ctx.snapshot();
+      expect(snap.containsKey('device.platform_brightness'), isTrue);
+      expect(snap.containsKey('device.text_scale_factor'), isFalse);
+      expect(snap.containsKey('device.reduce_motion'), isFalse);
+    });
+
+    test('accessibility keys present when opted in', () async {
+      final session = SessionManager();
+      await session.startSession('s');
+      final ctx = ContextManager(
+          sessionManager: session, captureAccessibilityContext: true);
+      final snap = ctx.snapshot();
+      expect(snap.containsKey('device.text_scale_factor'), isTrue);
+      expect(snap.containsKey('device.reduce_motion'), isTrue);
+    });
+  });
+
+  group('Navigation route context', () {
+    test('route.has_arguments is a boolean on navigation + screen.duration',
+        () {
+      final events = <(String, Map<String, String>?)>[];
+      final observer = EdgeNavigationObserver(
+          onEvent: (name, {attributes}) => events.add((name, attributes)));
+
+      final withArgs = MaterialPageRoute<void>(
+          builder: (_) => const SizedBox(),
+          settings: const RouteSettings(name: '/a', arguments: {'id': 1}));
+      final next = MaterialPageRoute<void>(
+          builder: (_) => const SizedBox(),
+          settings: const RouteSettings(name: '/b'));
+
+      observer.didPush(withArgs, null);
+      observer.didPush(next, withArgs); // closes /a → screen.duration
+
+      final nav = events.firstWhere((e) => e.$1 == 'navigation').$2!;
+      expect(nav['route.has_arguments'], 'true');
+      expect(nav['route.type'], 'MaterialPageRoute<void>');
+      // Never the values.
+      expect(nav.keys.any((k) => k.contains('arguments_type')), isFalse);
+
+      final dur = events.firstWhere((e) => e.$1 == 'screen.duration').$2!;
+      expect(dur['route.type'], 'MaterialPageRoute<void>');
+      expect(dur['route.has_arguments'], 'true');
+    });
+  });
+}


### PR DESCRIPTION
Closes #26.

## What
20-entry **crash-scoped breadcrumb ring** + the Flutter-unique "capture more" diagnostics (spec #15 Phase 3, glossary §1–6).

### Breadcrumbs
- Ring cap 50 → **20**, crash-scoped.
- Attached to every `app.crash` as `crash.breadcrumbs` (JSON-encoded) in the Collector — never in the global snapshot.
- Auto-crumbs: navigation, HTTP (**sanitized path only** — no query string/PII), lifecycle transitions.
- Manual: `addBreadcrumb(message, {category, level, data})` (`category` now optional, defaults to `custom`).

### Diagnostics
- `frame_render_time` → `build_time_ms` (UI-thread build) + `raster_time_ms` (GPU raster).
- `navigation` + `screen.duration` → `route.type` + `route.has_arguments` (**boolean only** — argument values never captured).
- `page_load` → `startup.type` (cold/warm) + `startup.time_to_first_frame_ms` (SDK-init-relative; README caveat). `startup.duration_ms` kept for backward-compat.
- `app_lifecycle` → `lifecycle.state` (raw `AppLifecycleState`).
- Every event → `device.platform_brightness`; `device.text_scale_factor` / `device.reduce_motion` gated behind new `initialize(captureAccessibilityContext:)` (default **off**, pending privacy sign-off).

## Tests
- New `test/unit/diagnostics/capture_more_test.dart`: ring cap, crash attach + scoping, device-context gating, route booleans.
- `wire_flip_test` `_normalize` updated to drop the new live device keys (owned by #26, not the #21 wire-flip canon).
- `flutter analyze` clean; **65 tests pass**.

## Reviewed
Two-axis `/code-review` (Standards + Spec) run before commit; findings applied — nav-observer parallel maps consolidated, `startup.duration_ms` restored (additive mandate), `addBreadcrumb` `category` made optional.

## Deferred
- Native crash payloads → breadcrumbs (Phase 4, #10).
- True cold/warm startup classification needs the native engine-init timeline (deferred to #10); current label is a documented duration-threshold heuristic.