### PR TITLE
wayfinder #27: iOS MetricKit native crash plugin

### DIFF
--- a/edge_telemetry_flutter/CHANGELOG.md
+++ b/edge_telemetry_flutter/CHANGELOG.md
@@ -113,6 +113,20 @@ section below. Final version bump + migration guide land with the rest of v2.0.0
   new `initialize(captureAccessibilityContext:)` flag (default `false`, pending
   privacy sign-off — they are accessibility-sensitive).
 
+### 📱 Native crash capture — iOS (Phase 4)
+- **ADDED**: iOS MetricKit plugin behind the `edge_telemetry/native_crash`
+  channel. `MXCrashDiagnostic` → `cause: NativeCrash`, `MXHangDiagnostic` →
+  `cause: Hang`, both `is_fatal: true`, `crash.source: metrickit`. Zero
+  hand-rolled signal handlers — Apple's supported diagnostic API only.
+  Payloads are cached on device and drained on next launch via
+  `drainNativeCrashes()`; MetricKit self-dedups and the drain reads-then-clears,
+  so an OS crash record is never re-read across launches. Raw call-stack JSON is
+  sent for server-side symbolication (no dSYM shipped in the SDK).
+- **⚠️ BUILD BREAK**: the package is now an iOS plugin with a **hard iOS 14
+  floor** (MetricKit diagnostics require it). Consumers must set
+  `platform :ios, '14.0'` (or higher) in their `Podfile`. Android native
+  capture ships separately.
+
 ### 🧹 Internal
 - **REMOVED**: `opentelemetry` dependency, `SpanManager`, `EventTrackerImpl`,
   the `EventTracker` interface, and the `useJsonFormat` dual-backend branches.

--- a/edge_telemetry_flutter/README.md
+++ b/edge_telemetry_flutter/README.md
@@ -26,6 +26,15 @@ dependencies:
   http: ^1.1.0  # If you're making HTTP requests
 ```
 
+### iOS requirement (native crash capture)
+
+Native iOS crash/hang capture uses **MetricKit**, which requires a **minimum
+deployment target of iOS 14**. Set it in your app's `ios/Podfile`:
+
+```ruby
+platform :ios, '14.0'
+```
+
 ## ⚡ Quick Start
 
 ### One-Line Setup (Everything Automatic!)

--- a/edge_telemetry_flutter/ios/Classes/EdgeTelemetryFlutterPlugin.swift
+++ b/edge_telemetry_flutter/ios/Classes/EdgeTelemetryFlutterPlugin.swift
@@ -1,0 +1,131 @@
+import Flutter
+import UIKit
+import MetricKit
+
+/// iOS native crash capture (#27, spec #15 Phase 4).
+///
+/// Pure MetricKit — no signal handlers, no watchdog threads. Subscribes to
+/// `MXMetricManager` at plugin registration; MetricKit delivers crash/hang
+/// diagnostic payloads on the *next launch* after the incident. Each payload is
+/// mapped to the unprefixed `app.crash` schema (see NativeCrashChannel) and
+/// cached to disk. Dart calls `drainNativeCrashes()` once on init to read and
+/// clear the cache.
+///
+/// Cross-launch dedup: MetricKit delivers each payload exactly once, and the
+/// drain reads-then-deletes the cache file — so an OS crash record is never
+/// re-read across launches (the iOS equivalent of the Android watermark).
+public class EdgeTelemetryFlutterPlugin: NSObject, FlutterPlugin, MXMetricManagerSubscriber {
+  private static let channelName = "edge_telemetry/native_crash"
+
+  private let store = CrashStore()
+
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    let channel = FlutterMethodChannel(
+      name: channelName, binaryMessenger: registrar.messenger())
+    let instance = EdgeTelemetryFlutterPlugin()
+    registrar.addMethodCallDelegate(instance, channel: channel)
+    MXMetricManager.shared.add(instance)
+  }
+
+  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "drainNativeCrashes":
+      result(store.drain())
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  // MARK: MXMetricManagerSubscriber
+
+  // Metrics payloads — not used here (crash capture only).
+  public func didReceive(_ payloads: [MXMetricPayload]) {}
+
+  public func didReceive(_ payloads: [MXDiagnosticPayload]) {
+    var crashes: [[String: String]] = []
+    for payload in payloads {
+      for c in payload.crashDiagnostics ?? [] { crashes.append(Self.map(crash: c)) }
+      for h in payload.hangDiagnostics ?? [] { crashes.append(Self.map(hang: h)) }
+    }
+    if !crashes.isEmpty { store.append(crashes) }
+  }
+
+  // MARK: Payload mapping (→ NativeCrashChannel schema, all-string values)
+
+  private static func map(crash c: MXCrashDiagnostic) -> [String: String] {
+    let exceptionType = c.exceptionType?.stringValue
+      ?? c.signal?.stringValue
+      ?? "unknown"
+    var parts: [String] = []
+    if let reason = c.terminationReason, !reason.isEmpty { parts.append(reason) }
+    if let signal = c.signal?.stringValue { parts.append("signal \(signal)") }
+    let message = parts.isEmpty ? "native crash" : parts.joined(separator: " ")
+    return [
+      "message": message,
+      "stacktrace": stack(c.callStackTree),
+      "exception_type": exceptionType,
+      "cause": "NativeCrash",
+      "is_fatal": "true",
+      "crash.source": "metrickit",
+    ]
+  }
+
+  private static func map(hang h: MXHangDiagnostic) -> [String: String] {
+    let seconds = h.hangDuration.converted(to: .seconds).value
+    return [
+      "message": String(format: "app hang %.1fs", seconds),
+      "stacktrace": stack(h.callStackTree),
+      "exception_type": "MXHangDiagnostic",
+      "cause": "Hang",
+      "is_fatal": "true",
+      "crash.source": "metrickit",
+    ]
+  }
+
+  // Raw, unsymbolicated call-stack JSON — server symbolicates.
+  private static func stack(_ tree: MXCallStackTree) -> String {
+    String(data: tree.jsonRepresentation(), encoding: .utf8) ?? ""
+  }
+}
+
+/// Disk-backed cache for crash payloads that arrive between launches.
+/// One JSON array file in Application Support; append is read-modify-write,
+/// drain is read-then-delete. A serial queue makes both atomic against the
+/// MetricKit delivery thread.
+private final class CrashStore {
+  private let queue = DispatchQueue(label: "edge_telemetry.crash_store")
+
+  private var fileURL: URL {
+    let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir.appendingPathComponent("edge_telemetry_native_crashes.json")
+  }
+
+  func append(_ crashes: [[String: String]]) {
+    queue.sync {
+      var all = read()
+      all.append(contentsOf: crashes)
+      write(all)
+    }
+  }
+
+  func drain() -> [[String: String]] {
+    queue.sync {
+      let all = read()
+      try? FileManager.default.removeItem(at: fileURL)
+      return all
+    }
+  }
+
+  private func read() -> [[String: String]] {
+    guard let data = try? Data(contentsOf: fileURL),
+      let json = try? JSONSerialization.jsonObject(with: data) as? [[String: String]]
+    else { return [] }
+    return json
+  }
+
+  private func write(_ crashes: [[String: String]]) {
+    guard let data = try? JSONSerialization.data(withJSONObject: crashes) else { return }
+    try? data.write(to: fileURL, options: .atomic)
+  }
+}

--- a/edge_telemetry_flutter/ios/edge_telemetry_flutter.podspec
+++ b/edge_telemetry_flutter/ios/edge_telemetry_flutter.podspec
@@ -1,0 +1,26 @@
+#
+# edge_telemetry_flutter — iOS plugin (#27).
+# MetricKit crash/hang diagnostics surfaced over the
+# `edge_telemetry/native_crash` MethodChannel. iOS 14 hard floor (MetricKit
+# diagnostic payloads require iOS 14) — this is the Podfile floor bump the v2
+# migration guide calls out.
+#
+Pod::Spec.new do |s|
+  s.name             = 'edge_telemetry_flutter'
+  s.version          = '1.6.0'
+  s.summary          = 'iOS MetricKit native crash capture for edge_telemetry_flutter.'
+  s.description      = <<-DESC
+Captures native crashes (MXCrashDiagnostic) and hangs (MXHangDiagnostic) via
+Apple MetricKit — zero hand-rolled signal handlers — and drains them to Dart
+on next launch over the edge_telemetry/native_crash channel.
+                       DESC
+  s.homepage         = 'https://github.com/NCG-Africa/edge_telemetry_flutter'
+  s.license          = { :file => '../LICENSE' }
+  s.author           = { 'NCG Africa' => 'movaaraconsult@gmail.com' }
+  s.source           = { :path => '.' }
+  s.source_files     = 'Classes/**/*'
+  s.dependency 'Flutter'
+  s.platform = :ios, '14.0'
+  s.swift_version = '5.0'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+end

--- a/edge_telemetry_flutter/pubspec.yaml
+++ b/edge_telemetry_flutter/pubspec.yaml
@@ -27,3 +27,11 @@ dev_dependencies:
   plugin_platform_interface: ^2.1.0
 
 flutter:
+  plugin:
+    platforms:
+      # iOS-only for now (#27): MetricKit native crash/hang capture.
+      # Android (#28) registers under `android:` when it lands. On any platform
+      # without a registered handler, drainNativeCrashes() no-ops via
+      # MissingPluginException (see NativeCrashChannel).
+      ios:
+        pluginClass: EdgeTelemetryFlutterPlugin


### PR DESCRIPTION
Closes #27. Stands up the package's first native layer — iOS only (Android is #28).

## What
- **Swift MetricKit subscriber** (`ios/Classes/EdgeTelemetryFlutterPlugin.swift`): `MXCrashDiagnostic` → `cause=NativeCrash`, `MXHangDiagnostic` → `cause=Hang`; `is_fatal=true`, `crash.source=metrickit`. Zero hand-rolled signal handlers.
- Maps to the unprefixed `app.crash` schema (`message`/`stacktrace`/`exception_type`/`cause`/`is_fatal`/`crash.source`) already published by `NativeCrashChannel` (#19), drained over `edge_telemetry/native_crash`. **Dart side unchanged** — `_drainNativeCrashes()` already calls the channel on init.
- Raw `callStackTree` JSON for server-side symbolication (no dSYM shipped).
- Cross-launch dedup via cache read-then-clear (MetricKit self-dedups; no timestamp watermark needed on iOS).
- **iOS 14 hard floor** — podspec `platform :ios, '14.0'` + README/CHANGELOG Podfile note.

## Acceptance criteria
- [x] Swift MetricKit: `MXCrashDiagnostic`→`NativeCrash`, `MXHangDiagnostic`→`Hang`; no signal handlers
- [x] `drainNativeCrashes()` returns payloads over the channel
- [x] Cross-launch re-reads prevented (read-then-clear; MetricKit self-dedups)
- [x] Raw stacks only (server-side symbolication)
- [x] iOS 14 Podfile floor set
- [ ] Builds on iOS; drain verified on device — **needs Xcode + physical device, not done in this environment**

## Verification
`flutter analyze` clean; 65/65 tests pass (Dart side unaffected). Reviewed via parallel Standards + Spec agents; fixed all findings (podspec/pubspec version alignment, README iOS-14 requirement, hang-duration formatting).