### PR TITLE
wayfinder #28: Android native crash plugin (JVM + ApplicationExitInfo)

### DIFF
--- a/edge_telemetry_flutter/CHANGELOG.md
+++ b/edge_telemetry_flutter/CHANGELOG.md
@@ -127,6 +127,25 @@ section below. Final version bump + migration guide land with the rest of v2.0.0
   `platform :ios, '14.0'` (or higher) in their `Podfile`. Android native
   capture ships separately.
 
+### 📱 Native crash capture — Android (Phase 4)
+- **ADDED**: Kotlin plugin behind the same `edge_telemetry/native_crash`
+  channel. JVM/Kotlin crashes via `Thread.setDefaultUncaughtExceptionHandler`
+  on **all** API levels (persist-then-chain, `crash.source: uncaught_handler`);
+  native + ANR crashes via `ActivityManager.getHistoricalProcessExitReasons`
+  (`ApplicationExitInfo`) on **API 30+** — `REASON_CRASH_NATIVE` →
+  `cause: NativeCrash`, `REASON_ANR` → `cause: ANR`, `crash.source:
+  app_exit_info`. Zero watchdogs, zero signal handlers. `REASON_CRASH` (JVM)
+  from `ApplicationExitInfo` is ignored so JVM crashes aren't double-reported.
+- **ADDED**: `sdk.native_capture_tier` on every Android crash payload — `full`
+  on API 30+ (JVM + native + ANR), `jvm_only` below (native/ANR is a documented
+  gap; the `ApplicationExitInfo` API doesn't exist pre-30). Per-device coverage
+  is honest on the dashboard.
+- A persisted watermark (last-seen exit timestamp) prevents re-reading OS exit
+  records across launches; JVM crash files are read-then-deleted on drain. Raw
+  tombstone / ANR traces are sent for server-side symbolication.
+- **No minimum-SDK bump** — the existing low floor is preserved
+  (`ApplicationExitInfo` is runtime-guarded for API 30+).
+
 ### 🧹 Internal
 - **REMOVED**: `opentelemetry` dependency, `SpanManager`, `EventTrackerImpl`,
   the `EventTracker` interface, and the `useJsonFormat` dual-backend branches.

--- a/edge_telemetry_flutter/README.md
+++ b/edge_telemetry_flutter/README.md
@@ -35,6 +35,22 @@ deployment target of iOS 14**. Set it in your app's `ios/Podfile`:
 platform :ios, '14.0'
 ```
 
+### Android coverage
+
+Android native crash capture is **tiered by OS version**, with no watchdog
+threads or hand-rolled signal handlers:
+
+| API level | JVM/Kotlin crashes | Native (NDK) crashes | ANRs | `sdk.native_capture_tier` |
+|-----------|:---:|:---:|:---:|:---:|
+| **30+**   | ✅ | ✅ | ✅ | `full` |
+| **< 30**  | ✅ | ❌ | ❌ | `jvm_only` |
+
+Below API 30, native (NDK) crashes and ANRs are a **documented gap** — the OS
+`ApplicationExitInfo` API that surfaces them only exists on API 30+. JVM crashes
+are captured on every level via `UncaughtExceptionHandler`. Each captured crash
+carries `sdk.native_capture_tier` so per-device coverage is visible on the
+dashboard. No minimum-SDK bump — the existing low floor is preserved.
+
 ## ⚡ Quick Start
 
 ### One-Line Setup (Everything Automatic!)

--- a/edge_telemetry_flutter/android/build.gradle
+++ b/edge_telemetry_flutter/android/build.gradle
@@ -1,0 +1,49 @@
+group 'com.ncgafrica.edge_telemetry_flutter'
+version '1.0'
+
+buildscript {
+    ext.kotlin_version = '1.9.10'
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    namespace 'com.ncgafrica.edge_telemetry_flutter'
+    compileSdk 34
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
+    // Keeps the existing low floor (Africa-market devices on 9/10 stay
+    // supported). ApplicationExitInfo is guarded at runtime for API 30+;
+    // JVM crash capture works on every level.
+    defaultConfig {
+        minSdk 19
+    }
+
+    dependencies {
+        implementation "androidx.annotation:annotation:1.7.1"
+    }
+}

--- a/edge_telemetry_flutter/android/src/main/AndroidManifest.xml
+++ b/edge_telemetry_flutter/android/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/edge_telemetry_flutter/android/src/main/kotlin/com/ncgafrica/edge_telemetry_flutter/EdgeTelemetryFlutterPlugin.kt
+++ b/edge_telemetry_flutter/android/src/main/kotlin/com/ncgafrica/edge_telemetry_flutter/EdgeTelemetryFlutterPlugin.kt
@@ -1,0 +1,172 @@
+package com.ncgafrica.edge_telemetry_flutter
+
+import android.app.ActivityManager
+import android.app.ApplicationExitInfo
+import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import io.flutter.plugin.common.MethodChannel.Result
+import org.json.JSONObject
+import java.io.File
+
+/**
+ * Android native crash capture (#28, spec #15 Phase 4).
+ *
+ * Two OS-diagnostic sources, no signal handlers and no watchdog threads:
+ *  - **JVM `UncaughtExceptionHandler`** (all API levels): the throwable is
+ *    written to a file as the process dies, then the previous handler runs.
+ *    Read + cleared on the next launch's drain. `crash.source=uncaught_handler`.
+ *  - **`ApplicationExitInfo`** (API 30+): on drain, the OS exit history is read
+ *    and `REASON_CRASH_NATIVE`→`NativeCrash`, `REASON_ANR`→`ANR` are emitted.
+ *    A persisted watermark (last-seen exit timestamp) stops re-reads across
+ *    launches. `crash.source=app_exit_info`.
+ *
+ * `REASON_CRASH` (JVM) from `ApplicationExitInfo` is ignored — the live handler
+ * above is the single source for JVM crashes, so we never double-report.
+ *
+ * Coverage is honest per device via `sdk.native_capture_tier`: `full` on API
+ * 30+ (JVM + native + ANR), `jvm_only` below (native/ANR is a documented gap —
+ * the OS-API-first trade for zero async-signal-safe native code).
+ *
+ * Stacks are raw/unsymbolicated — the server symbolicates. Payloads map to the
+ * unprefixed `app.crash` schema published by `NativeCrashChannel` and drained
+ * over `edge_telemetry/native_crash`; the Dart side is unchanged.
+ */
+class EdgeTelemetryFlutterPlugin : FlutterPlugin, MethodCallHandler {
+  private lateinit var channel: MethodChannel
+  private lateinit var appContext: Context
+
+  override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+    appContext = binding.applicationContext
+    channel = MethodChannel(binding.binaryMessenger, CHANNEL_NAME)
+    channel.setMethodCallHandler(this)
+    installJvmHandler()
+  }
+
+  override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+    channel.setMethodCallHandler(null)
+  }
+
+  override fun onMethodCall(call: MethodCall, result: Result) {
+    when (call.method) {
+      "drainNativeCrashes" -> result.success(drain())
+      else -> result.notImplemented()
+    }
+  }
+
+  // --- JVM crashes (all API levels) ---------------------------------------
+
+  /** Chain onto the default handler: persist, then let the process die. */
+  private fun installJvmHandler() {
+    val previous = Thread.getDefaultUncaughtExceptionHandler()
+    Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+      try {
+        persistJvmCrash(throwable)
+      } catch (_: Throwable) {
+        // best-effort in a dying process — never swallow the crash itself
+      }
+      previous?.uncaughtException(thread, throwable)
+    }
+  }
+
+  private fun persistJvmCrash(t: Throwable) {
+    val dir = File(appContext.filesDir, CRASH_DIR).apply { mkdirs() }
+    val json = JSONObject().apply {
+      put("message", t.message ?: t.javaClass.name)
+      put("stacktrace", t.stackTraceToString())
+      put("exception_type", t.javaClass.name)
+      put("cause", "NativeCrash")
+      put("is_fatal", "true")
+      put("crash.source", "uncaught_handler")
+      put("sdk.native_capture_tier", tier())
+    }
+    // One file per crash → no read-modify-write while the process is dying.
+    File(dir, "crash_${System.nanoTime()}.json").writeText(json.toString())
+  }
+
+  private fun readAndClearJvmCrashes(): List<Map<String, String>> {
+    val files = File(appContext.filesDir, CRASH_DIR).listFiles() ?: return emptyList()
+    val out = ArrayList<Map<String, String>>(files.size)
+    for (f in files) {
+      try {
+        val obj = JSONObject(f.readText())
+        val m = HashMap<String, String>()
+        for (key in obj.keys()) m[key] = obj.getString(key)
+        out.add(m)
+      } catch (_: Throwable) {
+        // corrupt/partial file — drop it
+      }
+      f.delete()
+    }
+    return out
+  }
+
+  // --- Native + ANR crashes (API 30+) -------------------------------------
+
+  @RequiresApi(Build.VERSION_CODES.R)
+  private fun readAppExitInfo(): List<Map<String, String>> {
+    val am = appContext.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+    val reasons = am.getHistoricalProcessExitReasons(null, 0, 0)
+    val prefs = appContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+    val watermark = prefs.getLong(KEY_WATERMARK, 0L)
+    var newest = watermark
+    val out = ArrayList<Map<String, String>>()
+    for (info in reasons) {
+      if (info.timestamp <= watermark) continue
+      if (info.timestamp > newest) newest = info.timestamp
+      val map = when (info.reason) {
+        // REASON_CRASH (JVM) is deliberately skipped — the live handler owns it.
+        ApplicationExitInfo.REASON_CRASH_NATIVE ->
+          mapExit(info, cause = "NativeCrash", exceptionType = "REASON_CRASH_NATIVE")
+        ApplicationExitInfo.REASON_ANR ->
+          mapExit(info, cause = "ANR", exceptionType = "REASON_ANR")
+        else -> null
+      }
+      if (map != null) out.add(map)
+    }
+    if (newest > watermark) prefs.edit().putLong(KEY_WATERMARK, newest).apply()
+    return out
+  }
+
+  @RequiresApi(Build.VERSION_CODES.R)
+  private fun mapExit(info: ApplicationExitInfo, cause: String): Map<String, String> = mapOf(
+    "message" to (info.description ?: cause),
+    "stacktrace" to readTrace(info),
+    "exception_type" to "REASON_${info.reason}",
+    "cause" to cause,
+    "is_fatal" to "true",
+    "crash.source" to "app_exit_info",
+    "sdk.native_capture_tier" to tier(),
+  )
+
+  /** Raw tombstone (native) or ANR trace — the OS provides it for these reasons. */
+  @RequiresApi(Build.VERSION_CODES.R)
+  private fun readTrace(info: ApplicationExitInfo): String = try {
+    info.traceInputStream?.bufferedReader()?.use { it.readText() } ?: ""
+  } catch (_: Throwable) {
+    ""
+  }
+
+  // --- Drain --------------------------------------------------------------
+
+  private fun drain(): List<Map<String, String>> {
+    val out = ArrayList<Map<String, String>>()
+    out.addAll(readAndClearJvmCrashes())
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) out.addAll(readAppExitInfo())
+    return out
+  }
+
+  private fun tier(): String =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) "full" else "jvm_only"
+
+  companion object {
+    private const val CHANNEL_NAME = "edge_telemetry/native_crash"
+    private const val PREFS = "edge_telemetry_native_crash"
+    private const val KEY_WATERMARK = "aei_watermark"
+    private const val CRASH_DIR = "edge_telemetry_crashes"
+  }
+}

--- a/edge_telemetry_flutter/pubspec.yaml
+++ b/edge_telemetry_flutter/pubspec.yaml
@@ -29,9 +29,14 @@ dev_dependencies:
 flutter:
   plugin:
     platforms:
-      # iOS-only for now (#27): MetricKit native crash/hang capture.
-      # Android (#28) registers under `android:` when it lands. On any platform
+      # Native crash capture (#27 iOS MetricKit, #28 Android). On any platform
       # without a registered handler, drainNativeCrashes() no-ops via
       # MissingPluginException (see NativeCrashChannel).
       ios:
+        pluginClass: EdgeTelemetryFlutterPlugin
+      # Android (#28): JVM UncaughtExceptionHandler (all APIs) + ApplicationExitInfo
+      # native/ANR (API 30+). Pre-30 native/ANR is a documented gap surfaced via
+      # sdk.native_capture_tier.
+      android:
+        package: com.ncgafrica.edge_telemetry_flutter
         pluginClass: EdgeTelemetryFlutterPlugin

--- a/edge_telemetry_flutter/test/unit/crash/native_crash_channel_test.dart
+++ b/edge_telemetry_flutter/test/unit/crash/native_crash_channel_test.dart
@@ -42,4 +42,25 @@ void main() {
     messenger.setMockMethodCallHandler(channel, (call) async => null);
     expect(await NativeCrashChannel().drainNativeCrashes(), isEmpty);
   });
+
+  test('passes through Android keys (tier + app_exit_info source)', () async {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      return <dynamic>[
+        {
+          'message': 'ANR in com.example',
+          'stacktrace': 'main thread trace',
+          'exception_type': 'REASON_ANR',
+          'cause': 'ANR',
+          'is_fatal': 'true',
+          'crash.source': 'app_exit_info',
+          'sdk.native_capture_tier': 'full',
+        },
+      ];
+    });
+
+    final crashes = await NativeCrashChannel().drainNativeCrashes();
+    expect(crashes.first['cause'], 'ANR');
+    expect(crashes.first['crash.source'], 'app_exit_info');
+    expect(crashes.first['sdk.native_capture_tier'], 'full');
+  });
 }


### PR DESCRIPTION
Closes #28. Android half of the native crash layer (iOS was #27), behind the same `edge_telemetry/native_crash` MethodChannel — **Dart side unchanged** (#19 contract).

## What
- **Kotlin plugin** (`android/.../EdgeTelemetryFlutterPlugin.kt`):
  - JVM/Kotlin crashes via `Thread.setDefaultUncaughtExceptionHandler` on **all** API levels — persist-then-chain, one file per crash (no read-modify-write in a dying process). `crash.source=uncaught_handler`.
  - Native + ANR via `ActivityManager.getHistoricalProcessExitReasons` (`ApplicationExitInfo`) on **API 30+**: `REASON_CRASH_NATIVE → NativeCrash`, `REASON_ANR → ANR`. `crash.source=app_exit_info`.
  - Zero watchdogs, zero signal handlers.
- `REASON_CRASH` (JVM) from `ApplicationExitInfo` is **ignored** — the live handler is the single source for JVM crashes, so no double-report.
- **Watermark** (last-seen exit timestamp) prevents re-reading OS exit records across launches; JVM crash files read-then-deleted on drain.
- **`sdk.native_capture_tier`** on every payload: `full` on API 30+, `jvm_only` below. Pre-30 native/ANR is a documented gap (README table + CHANGELOG + wayfinder doc).
- Raw tombstone/ANR traces for server-side symbolication. **No minSdk bump** — `ApplicationExitInfo` runtime-guarded for API 30+, low floor preserved.

## Acceptance criteria
- [x] Kotlin `UncaughtExceptionHandler` (all APIs) + `ApplicationExitInfo` (API 30+); no watchdogs
- [x] `drainNativeCrashes()` over channel; watermark prevents re-reads
- [x] `sdk.native_capture_tier` = `full` / `jvm_only` emitted
- [x] pre-API-30 native/ANR gap documented
- [ ] Builds on Android; drain verified on device matrix — **pending** (needs an Android host app + devices; can't run in this environment)

## Tests
`flutter analyze` clean; full suite green (66 tests), incl. a Dart passthrough test for the Android-only keys.