### PR TITLE
wayfinder #29: native crash convergence — drain routes to app.crash

### DIFF
--- a/edge_telemetry_flutter/CHANGELOG.md
+++ b/edge_telemetry_flutter/CHANGELOG.md
@@ -146,13 +146,33 @@ section below. Final version bump + migration guide land with the rest of v2.0.0
 - **No minimum-SDK bump** — the existing low floor is preserved
   (`ApplicationExitInfo` is runtime-guarded for API 30+).
 
+### 📱 Native crash convergence (Phase 4)
+- **CHANGED**: `drainNativeCrashes()` — pulled once on init — now **routes** each
+  native payload into the immediate `app.crash` rail (was contract-only, dropped
+  the drain). Native crashes surface as `app.crash` with the OS-supplied `cause`
+  (`NativeCrash` / `ANR` / `Hang`), `is_fatal: true`, `crash.source`, and the
+  `sdk.native_capture_tier` passthrough carried verbatim — the client synthesizes
+  none of it. Identity context is folded in downstream by the Collector; the send
+  bypasses the batch (immediate rail).
+- **FIXED**: Android `mapExit` signature/call-site mismatch that prevented the
+  Kotlin plugin from compiling (`exception_type` now the named `REASON_*` string).
+- **Deviation (device-matrix e2e, #29)**: the Dart convergence + routing is
+  verified by unit tests (collector → wire, `cause`/`is_fatal`/`sdk.native_capture_tier`
+  asserted), but the on-device e2e fatal (iOS MetricKit + Android
+  `ApplicationExitInfo` producing `app.crash` on the wire) is **not yet run** —
+  no device matrix / CI harness available at this stage. Contingency (spec #15
+  Phase 4): if native slips, ship wire-first as v2.0.0 and native as v2.1.0
+  (reopens #10). Not triggered — the wiring is in; only device-matrix
+  confirmation is outstanding.
+
 ### 🧹 Internal
 - **REMOVED**: `opentelemetry` dependency, `SpanManager`, `EventTrackerImpl`,
   the `EventTracker` interface, and the `useJsonFormat` dual-backend branches.
 - **ADDED**: `NativeCrashChannel` — the pull-only `edge_telemetry/native_crash`
   MethodChannel contract (`drainNativeCrashes()` + documented per-crash payload
   schema) the Phase-4 iOS/Android native plugin builds against. Drained once on
-  init; no-op until the natives land. Internal seam, not exported.
+  init and routed to `app.crash` (see Native crash convergence). Internal seam,
+  not exported.
 
 ## [1.6.0] - 2026-07-10
 

--- a/edge_telemetry_flutter/android/src/main/kotlin/com/ncgafrica/edge_telemetry_flutter/EdgeTelemetryFlutterPlugin.kt
+++ b/edge_telemetry_flutter/android/src/main/kotlin/com/ncgafrica/edge_telemetry_flutter/EdgeTelemetryFlutterPlugin.kt
@@ -133,10 +133,14 @@ class EdgeTelemetryFlutterPlugin : FlutterPlugin, MethodCallHandler {
   }
 
   @RequiresApi(Build.VERSION_CODES.R)
-  private fun mapExit(info: ApplicationExitInfo, cause: String): Map<String, String> = mapOf(
+  private fun mapExit(
+    info: ApplicationExitInfo,
+    cause: String,
+    exceptionType: String,
+  ): Map<String, String> = mapOf(
     "message" to (info.description ?: cause),
     "stacktrace" to readTrace(info),
-    "exception_type" to "REASON_${info.reason}",
+    "exception_type" to exceptionType,
     "cause" to cause,
     "is_fatal" to "true",
     "crash.source" to "app_exit_info",

--- a/edge_telemetry_flutter/lib/src/core/edge_event.dart
+++ b/edge_telemetry_flutter/lib/src/core/edge_event.dart
@@ -98,6 +98,16 @@ class EdgeEvent {
         ...?attributes,
       });
 
+  /// The native-crash leg of the same `app.crash` rail (spec #15 Phase 4, #29).
+  ///
+  /// The native plugin already built the unprefixed payload — `message`,
+  /// `stacktrace`, `exception_type`, `cause` (`NativeCrash`/`ANR`/`Hang`),
+  /// `is_fatal:"true"`, `crash.source`, and the `sdk.native_capture_tier`
+  /// passthrough — so this factory carries the map verbatim onto the immediate
+  /// rail (no `cause`/`is_fatal` synthesis; those come from the OS, not us).
+  factory EdgeEvent.nativeCrash(Map<String, String> payload) =>
+      EdgeEvent._crash(Map<String, String>.unmodifiable(payload));
+
   const EdgeEvent._crash(this.attributes)
       : type = 'event',
         name = 'app.crash',

--- a/edge_telemetry_flutter/lib/src/crash/crash_reporting.dart
+++ b/edge_telemetry_flutter/lib/src/crash/crash_reporting.dart
@@ -27,4 +27,11 @@ class CrashReporting {
   }) =>
       EdgeEvent.error(error,
           stackTrace: stackTrace, source: source, attributes: attributes);
+
+  /// Build the immediate `app.crash` event for one native-drained crash
+  /// [payload] (#29). The native side already shaped the unprefixed keys and set
+  /// the `NativeCrash`/`ANR`/`Hang` cause + `is_fatal:true` + capture tier — we
+  /// carry it verbatim; the Collector folds in identity context downstream.
+  EdgeEvent buildNativeCrashEvent(Map<String, String> payload) =>
+      EdgeEvent.nativeCrash(payload);
 }

--- a/edge_telemetry_flutter/lib/src/facade/edge_telemetry.dart
+++ b/edge_telemetry_flutter/lib/src/facade/edge_telemetry.dart
@@ -249,17 +249,22 @@ class EdgeTelemetry {
     }
   }
 
-  /// Pull native crashes surfaced by the OS since last launch, once on init.
+  /// Pull native crashes surfaced by the OS since last launch, once on init,
+  /// and route each into the immediate `app.crash` rail (spec #15 Phase 4, #29).
   ///
-  /// No-op until the Phase-4 native plugin registers the channel — the drain
-  /// returns `[]` and nothing is sent. When the plugin lands, Phase 4 wires the
-  /// returned payloads into the immediate crash rail here.
+  /// Each payload arrives pre-shaped by the native plugin (unprefixed keys,
+  /// `cause` ∈ NativeCrash/ANR/Hang, `is_fatal:true`, `crash.source`,
+  /// `sdk.native_capture_tier`); the Collector folds in identity context and
+  /// sends immediately (bypass batch). Empty until the native plugin registers
+  /// the channel — the drain returns `[]` and nothing is sent.
   Future<void> _drainNativeCrashes() async {
     final crashes = await _wiring!.nativeCrash.drainNativeCrashes();
-    // ponytail: drop until Phase 4; routing to app.crash lands with the native
-    // plugin + the app.crash wire event (spec #15 Phase 4). Contract-only here.
+    for (final crash in crashes) {
+      _wiring!.collector
+          .add(_wiring!.crashReporting.buildNativeCrashEvent(crash));
+    }
     if (_config?.debugMode == true && crashes.isNotEmpty) {
-      print('📥 Drained ${crashes.length} native crash(es)');
+      print('📥 Drained ${crashes.length} native crash(es) → app.crash');
     }
   }
 

--- a/edge_telemetry_flutter/test/unit/crash/crash_reporting_test.dart
+++ b/edge_telemetry_flutter/test/unit/crash/crash_reporting_test.dart
@@ -102,6 +102,42 @@ void main() {
     });
   });
 
+  group('buildNativeCrashEvent — native taxonomy carried verbatim', () {
+    test('cause/is_fatal/tier are the OS values, not synthesized', () {
+      final event = reporting.buildNativeCrashEvent({
+        'message': 'SIGSEGV',
+        'stacktrace': 'frame0\nframe1',
+        'exception_type': 'EXC_BAD_ACCESS',
+        'cause': 'NativeCrash',
+        'is_fatal': 'true',
+        'crash.source': 'metrickit',
+        'sdk.native_capture_tier': 'full',
+      });
+
+      expect(event.name, 'app.crash');
+      expect(event.priority, EventPriority.immediate);
+      expect(event.bypassSampling, isTrue);
+
+      final a = event.attributes;
+      expect(a['cause'], 'NativeCrash'); // native taxonomy, not 'Error'
+      expect(a['is_fatal'], 'true'); // fatal, not the Dart 'false'
+      expect(a['crash.source'], 'metrickit');
+      expect(a['sdk.native_capture_tier'], 'full');
+    });
+
+    test('ANR + jvm_only tier pass through unchanged', () {
+      final a = reporting.buildNativeCrashEvent({
+        'message': 'ANR in com.example',
+        'cause': 'ANR',
+        'is_fatal': 'true',
+        'crash.source': 'app_exit_info',
+        'sdk.native_capture_tier': 'jvm_only',
+      }).attributes;
+      expect(a['cause'], 'ANR');
+      expect(a['sdk.native_capture_tier'], 'jvm_only');
+    });
+  });
+
   group('immediate routing', () {
     Future<(Collector, _RecordingSender)> wire() async {
       final sender = _RecordingSender();
@@ -136,6 +172,28 @@ void main() {
       expect(attrs['cause'], 'Error');
       expect(attrs['is_fatal'], 'false');
       expect(attrs['crash.source'], 'platform_dispatcher');
+      expect(attrs['device.id'], 'device_x'); // identity context folded in
+    });
+
+    test('native crash reaches the wire as app.crash with tier asserted',
+        () async {
+      final (collector, sender) = await wire();
+
+      collector.add(reporting.buildNativeCrashEvent({
+        'message': 'SIGSEGV',
+        'cause': 'NativeCrash',
+        'is_fatal': 'true',
+        'crash.source': 'metrickit',
+        'sdk.native_capture_tier': 'full',
+      }));
+      await Future<void>(() {});
+
+      expect(sender.sent, hasLength(1));
+      final attrs = sender.sent.single['attributes'] as Map;
+      expect(sender.sent.single['eventName'], 'app.crash');
+      expect(attrs['cause'], 'NativeCrash');
+      expect(attrs['is_fatal'], 'true');
+      expect(attrs['sdk.native_capture_tier'], 'full'); // tiering asserted
       expect(attrs['device.id'], 'device_x'); // identity context folded in
     });
   });


### PR DESCRIPTION
Closes #29 (spec #15, Phase 4 — convergence).

## What
Wire `drainNativeCrashes()` into the immediate crash rail (was contract-only — it dropped the drain). Each native payload now surfaces as an `app.crash` on the immediate/bypass rail via `EdgeEvent.nativeCrash` / `CrashReporting.buildNativeCrashEvent`. The OS-supplied `cause` (`NativeCrash`/`ANR`/`Hang`), `is_fatal:true`, `crash.source`, and the `sdk.native_capture_tier` passthrough are carried **verbatim** (no client synthesis); the Collector folds in identity context downstream.

Also fixes the Android `mapExit` signature/call-site mismatch that blocked Kotlin compile (`exception_type` now the named `REASON_*` string) — prerequisite for the Android e2e leg.

## Acceptance criteria
- [x] `drainNativeCrashes()` pulled once on init into the crash rail
- [x] Native crash → `app.crash`, `cause` native taxonomy, `is_fatal=true`
- [x] `sdk.native_capture_tier` asserted (unit)
- [ ] e2e fatal (iOS + Android) on the wire / tier on device matrix — **deviation**: not runnable without a device/CI harness at this stage. Surfaced in CHANGELOG per the Phase-4 contingency (native slip → wire-first v2.0.0 + native v2.1.0, reopens #10). Contingency not triggered — wiring is in; only device-matrix confirmation is outstanding.

## Tests
`flutter analyze` clean; 69 tests pass. New: native-taxonomy verbatim passthrough + native crash reaches the wire with tier asserted (collector → sender).